### PR TITLE
Override known dups

### DIFF
--- a/app/assets/javascripts/rails_admin/custom/initialize_confirm_modal.js
+++ b/app/assets/javascripts/rails_admin/custom/initialize_confirm_modal.js
@@ -1,0 +1,3 @@
+$(document).ready(function(){
+    $("#confirmModal").modal('show');
+});

--- a/app/controllers/custom_admin/publication_merges_controller.rb
+++ b/app/controllers/custom_admin/publication_merges_controller.rb
@@ -11,14 +11,28 @@ class CustomAdmin::PublicationMergesController < RailsAdmin::ApplicationControll
         return
       end
 
+      if params[:known_non_duplicate]
+        pub_ids = [params[:selected_publication_ids], params[:merge_target_publication_id]].flatten
+        known_non_dup_ids = []
+        pub_ids.each do |pub_id|
+          known_non_dup_ids << Publication.find(pub_id).non_duplicate_group_ids
+        end
+        hashed_kwn_non_dup = known_non_dup_ids.flatten.inject(Hash.new(0)) { |total, e| total[e] += 1 ;total }
+        ids_to_delete = hashed_kwn_non_dup.collect { |k, v| k if v > 1 }.compact
+        ids_to_delete.each do |id|
+          NonDuplicatePublicationGroup.destroy(id)
+        end
+      end
+
       merge_target_pub = group.publications.find(params[:merge_target_publication_id])
       selected_pubs = group.publications.find(params[:selected_publication_ids])
 
       begin
         merge_target_pub.merge!(selected_pubs)
       rescue Publication::NonDuplicateMerge
-        flash[:error] = I18n.t('admin.publication_merges.create.non_duplicate_merge_error')
-        redirect_to rails_admin.show_path(model_name: :duplicate_publication_group, id: group.id)
+        redirect_to rails_admin.show_path(model_name: :duplicate_publication_group, id: group.id, render_modal: true,
+                                          merge_target_publication_id: params[:merge_target_publication_id],
+                                          selected_publication_ids: params[:selected_publication_ids])
         return
       end
 

--- a/app/views/rails_admin/partials/duplicate_publication_groups/_confirm_dialog.html.erb
+++ b/app/views/rails_admin/partials/duplicate_publication_groups/_confirm_dialog.html.erb
@@ -11,7 +11,6 @@
       </div>
       <div class="modal-footer">
         <div class="col-sm-9">
-<!--          <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>-->
           <%= button_to "Cancel",
                         Rails.application.routes.url_helpers.admin_duplicate_publication_group_path(params[:id]),
                         method: :get,

--- a/app/views/rails_admin/partials/duplicate_publication_groups/_confirm_dialog.html.erb
+++ b/app/views/rails_admin/partials/duplicate_publication_groups/_confirm_dialog.html.erb
@@ -1,0 +1,36 @@
+<div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="exampleModalLabel">Override Known Non-Duplicates?</h4>
+      </div>
+      <div class="modal-body">
+        <p>This group contains a collection of publications that have been marked as non-duplicates.
+           If you are sure you want to merge these duplicates, click "Continue".
+           If you do not want to merge these duplicates, click "Cancel". </p>
+      </div>
+      <div class="modal-footer">
+        <div class="col-sm-9">
+<!--          <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>-->
+          <%= button_to "Cancel",
+                        Rails.application.routes.url_helpers.admin_duplicate_publication_group_path(params[:id]),
+                        method: :get,
+                        id: 'cancel-override-button',
+                        class: 'btn btn-secondary' %>
+        </div>
+        <div class="col-sm-2">
+          <%= button_to "Continue",
+                        Rails.application.routes.url_helpers.admin_duplicate_publication_group_merge_path(params[:id]),
+                        params: { commit: 'Merge Selected',
+                                  known_non_duplicate: true,
+                                  merge_target_publication_id: params[:merge_target_publication_id],
+                                  selected_publication_ids: params[:selected_publication_ids]
+                        },
+                        method: :post,
+                        id: 'merge-override-button',
+                        class: 'btn btn-primary' %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/rails_admin/partials/duplicate_publication_groups/_publications.html.erb
+++ b/app/views/rails_admin/partials/duplicate_publication_groups/_publications.html.erb
@@ -1,11 +1,5 @@
-<%= render partial: 'rails_admin/partials/duplicate_publication_groups/confirm_dialog' %>
-<% if params[:render_modal] %>
-  <script>
-    $(document).ready(function(){
-      $("#confirmModal").modal('show');
-    });
-  </script>
-<% end %>
+<%= render partial: 'rails_admin/partials/duplicate_publication_groups/confirm_dialog' if params[:render_modal] %>
+
 <%= form_tag Rails.application.routes.url_helpers.admin_duplicate_publication_group_merge_path(@object) do %>
   <div class="scroll-wrapper1">
     <div class="scroll-top"></div>

--- a/app/views/rails_admin/partials/duplicate_publication_groups/_publications.html.erb
+++ b/app/views/rails_admin/partials/duplicate_publication_groups/_publications.html.erb
@@ -1,3 +1,11 @@
+<%= render partial: 'rails_admin/partials/duplicate_publication_groups/confirm_dialog' %>
+<% if params[:render_modal] %>
+  <script>
+    $(document).ready(function(){
+      $("#confirmModal").modal('show');
+    });
+  </script>
+<% end %>
 <%= form_tag Rails.application.routes.url_helpers.admin_duplicate_publication_group_merge_path(@object) do %>
   <div class="scroll-wrapper1">
     <div class="scroll-top"></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,7 +14,6 @@ en:
       create:
         merge_success: "The publications were successfully merged."
         missing_params_error: "To perform a merge, you must select a merge target and at least one other publication to merge into the target."
-        non_duplicate_merge_error: "Some of the selected publications cannot be merged because they have already been identified as non-duplicates."
         too_few_pubs_to_ignore_error: "You must select at least two publications that are false duplicates to ignore."
         ignore_success: "The suspected duplication of the selected publications has been ignored. These publications will no longer be automatically grouped as duplicates, and they will be prevented from being merged."
     publication_waiver_links:

--- a/spec/integration/admin/publication_merges/create_spec.rb
+++ b/spec/integration/admin/publication_merges/create_spec.rb
@@ -381,14 +381,5 @@ feature "managing duplicate publication groups", type: :feature do
         expect(page).to have_content I18n.t('admin.publication_merges.create.ignore_success')
       end
     end
-
-    context "when the publications to merge share a non duplicate group" do
-      let!(:non_duplicate_group) { FactoryBot.create :non_duplicate_publication_group }
-      before do
-        non_duplicate_group.publications << [pub1, pub2]
-      end
-
-
-    end
   end
 end


### PR DESCRIPTION
Detects non-duplicate groups when merging duplicate groups and prompts the admin if they are sure and want to proceed.

#120