### PR TITLE
Remove tzinfo-data gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -168,6 +168,3 @@ group :test do
   # Extracted test matchers for rails controllers
   gem 'rails-controller-testing'
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]


### PR DESCRIPTION
This isn't needed for any of the specified platforms.