### PR TITLE
OAB publication importer: update publications with existing OA URLs

### DIFF
--- a/app/importers/open_access_button_publication_importer.rb
+++ b/app/importers/open_access_button_publication_importer.rb
@@ -24,7 +24,7 @@ class OpenAccessButtonPublicationImporter
   private
 
   def all_pubs
-    Publication.where.not(doi: nil).where.not(doi: '').where(%{open_access_url IS NULL OR open_access_url = ''})
+    Publication.where.not(doi: nil).where.not(doi: '')
   end
 
   def new_pubs

--- a/spec/component/importers/open_access_button_publication_importer_spec.rb
+++ b/spec/component/importers/open_access_button_publication_importer_spec.rb
@@ -89,14 +89,14 @@ describe OpenAccessButtonPublicationImporter do
         context "when the publication already has an open access URL" do
           before { pub.update_attribute(:open_access_url, "existing_url") }
 
-          it "does not update the publication's open access URL" do
+          it "updates the publication with the URL to the open access content" do
             importer.import_all
-            expect(pub.reload.open_access_url).to eq "existing_url"
+            expect(pub.reload.open_access_url).to eq "http://openaccessexample.org/publications/pub1.pdf"
           end
     
-          it "does not update the publication's Open Access Button check timestamp" do
+          it "updates Open Access Button check timestamp on the publication" do
             importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now - 32.days
+            expect(pub.reload.open_access_button_last_checked_at).to eq now
           end
         end
       end
@@ -114,14 +114,14 @@ describe OpenAccessButtonPublicationImporter do
         context "when the publication already has an open access URL" do
           before { pub.update_attribute(:open_access_url, "existing_url") }
 
-          it "does not update the publication's open access URL" do
+          it "updates the publication with the URL to the open access content" do
             importer.import_all
-            expect(pub.reload.open_access_url).to eq "existing_url"
+            expect(pub.reload.open_access_url).to eq "http://openaccessexample.org/publications/pub1.pdf"
           end
     
-          it "does not update the publication's Open Access Button check timestamp" do
+          it "updates Open Access Button check timestamp on the publication" do
             importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to be_nil
+            expect(pub.reload.open_access_button_last_checked_at).to eq now
           end
         end
       end
@@ -184,9 +184,9 @@ describe OpenAccessButtonPublicationImporter do
             expect(pub.reload.open_access_url).to eq "existing_url"
           end
     
-          it "does not update the publication's Open Access Button check timestamp" do
+          it "updates Open Access Button check timestamp on the publication" do
             importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now - 32.days
+            expect(pub.reload.open_access_button_last_checked_at).to eq now
           end
         end
       end
@@ -226,10 +226,10 @@ describe OpenAccessButtonPublicationImporter do
             importer.import_all
             expect(pub.reload.open_access_url).to eq "existing_url"
           end
-    
-          it "does not update the publication's Open Access Button check timestamp" do
+
+          it "updates Open Access Button check timestamp on the publication" do
             importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to be_nil
+            expect(pub.reload.open_access_button_last_checked_at).to eq now
           end
         end
       end
@@ -354,14 +354,14 @@ describe OpenAccessButtonPublicationImporter do
         context "when the publication already has an open access URL" do
           before { pub.update_attribute(:open_access_url, "existing_url") }
 
-          it "does not update the publication's open access URL" do
+          it "updates the publication with the URL to the open access content" do
             importer.import_new
-            expect(pub.reload.open_access_url).to eq "existing_url"
+            expect(pub.reload.open_access_url).to eq "http://openaccessexample.org/publications/pub1.pdf"
           end
     
-          it "does not update the publication's Open Access Button check timestamp" do
-            importer.import_new
-            expect(pub.reload.open_access_button_last_checked_at).to be_nil
+          it "updates Open Access Button check timestamp on the publication" do
+            importer.import_all
+            expect(pub.reload.open_access_button_last_checked_at).to eq now
           end
         end
       end
@@ -467,9 +467,9 @@ describe OpenAccessButtonPublicationImporter do
             expect(pub.reload.open_access_url).to eq "existing_url"
           end
     
-          it "does not update the publication's Open Access Button check timestamp" do
-            importer.import_new
-            expect(pub.reload.open_access_button_last_checked_at).to be_nil
+          it "updates Open Access Button check timestamp on the publication" do
+            importer.import_all
+            expect(pub.reload.open_access_button_last_checked_at).to eq now
           end
         end
       end


### PR DESCRIPTION
Closes #190.

The logic for `import_all` has been modified to now query for all publications that have a DOI, regardless of whether they have an open access URL or not. This will have the effect of allowing the OAB publication importer to correct any incorrect URLs that we may have previously received from the OAB API.