### PR TITLE
STI base class for recording importer errors

### DIFF
--- a/app/models/importer_error_log.rb
+++ b/app/models/importer_error_log.rb
@@ -1,0 +1,8 @@
+class ImporterErrorLog < ApplicationRecord
+  self.inheritance_column = "importer_type"
+
+  validates :error_type,
+            :stacktrace,
+            :occurred_at,
+            presence: true
+end

--- a/app/models/importer_error_log/activity_insight_importer_error_log.rb
+++ b/app/models/importer_error_log/activity_insight_importer_error_log.rb
@@ -1,0 +1,2 @@
+class ImporterErrorLog::ActivityInsightImporterErrorLog < ImporterErrorLog
+end

--- a/app/models/importer_error_log/open_access_button_importer_error_log.rb
+++ b/app/models/importer_error_log/open_access_button_importer_error_log.rb
@@ -1,0 +1,2 @@
+class ImporterErrorLog::OpenAccessButtonImporterErrorLog < ImporterErrorLog
+end

--- a/db/migrate/20211006155521_create_importer_error_logs.rb
+++ b/db/migrate/20211006155521_create_importer_error_logs.rb
@@ -1,0 +1,13 @@
+class CreateImporterErrorLogs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :importer_error_logs do |t|
+      t.string :importer_type, null: false
+      t.string :error_type, null: false
+      t.text :stacktrace, null: false
+      t.datetime :occurred_at, null: false
+      t.jsonb :metadata
+      t.timestamps
+    end
+    add_index :importer_error_logs, :importer_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_23_143828) do
+ActiveRecord::Schema.define(version: 2021_10_06_155521) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -193,6 +193,17 @@ ActiveRecord::Schema.define(version: 2021_07_23_143828) do
     t.index ["identifier"], name: "index_grants_on_identifier"
     t.index ["wos_agency_name"], name: "index_grants_on_wos_agency_name"
     t.index ["wos_identifier"], name: "index_grants_on_wos_identifier"
+  end
+
+  create_table "importer_error_logs", force: :cascade do |t|
+    t.string "importer_type", null: false
+    t.string "error_type", null: false
+    t.text "stacktrace", null: false
+    t.datetime "occurred_at", null: false
+    t.jsonb "metadata"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["importer_type"], name: "index_importer_error_logs_on_importer_type"
   end
 
   create_table "internal_publication_waivers", force: :cascade do |t|

--- a/spec/component/models/importer_error_log/activity_insight_importer_error_log_spec.rb
+++ b/spec/component/models/importer_error_log/activity_insight_importer_error_log_spec.rb
@@ -1,0 +1,7 @@
+require 'component/component_spec_helper'
+require 'component/models/shared_examples_for_an_importer_error_log'
+
+
+describe ImporterErrorLog::ActivityInsightImporterErrorLog, type: :model do
+  it_behaves_like "an importer error log"
+end

--- a/spec/component/models/importer_error_log/open_access_button_importer_error_log_spec.rb
+++ b/spec/component/models/importer_error_log/open_access_button_importer_error_log_spec.rb
@@ -1,0 +1,7 @@
+require 'component/component_spec_helper'
+require 'component/models/shared_examples_for_an_importer_error_log'
+
+
+describe ImporterErrorLog::OpenAccessButtonImporterErrorLog, type: :model do
+  it_behaves_like "an importer error log"
+end

--- a/spec/component/models/importer_error_log_spec.rb
+++ b/spec/component/models/importer_error_log_spec.rb
@@ -1,0 +1,26 @@
+require 'component/component_spec_helper'
+require 'component/models/shared_examples_for_an_application_record'
+
+describe 'the import_error_logs table', type: :model do
+  subject { ImporterErrorLog.new }
+
+
+  it { is_expected.to have_db_column(:id).of_type(:integer).with_options(null: false) }
+  it { is_expected.to have_db_column(:importer_type).of_type(:string).with_options(null: false) }
+  it { is_expected.to have_db_column(:error_type).of_type(:string).with_options(null: false) }
+  it { is_expected.to have_db_column(:stacktrace).of_type(:text).with_options(null: false) }
+  it { is_expected.to have_db_column(:metadata).of_type(:jsonb) }
+  it { is_expected.to have_db_column(:occurred_at).of_type(:datetime).with_options(null: false) }
+  it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
+  it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
+
+  it { is_expected.to have_db_index(:importer_type) }
+end
+
+describe ImporterErrorLog, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:error_type) }
+    it { is_expected.to validate_presence_of(:stacktrace) }
+    it { is_expected.to validate_presence_of(:occurred_at) }
+  end
+end

--- a/spec/component/models/shared_examples_for_an_importer_error_log.rb
+++ b/spec/component/models/shared_examples_for_an_importer_error_log.rb
@@ -1,0 +1,4 @@
+shared_examples_for "an importer error log" do
+  specify { expect(described_class).to be < ImporterErrorLog }
+  specify { expect(described_class.table_name).to eq ImporterErrorLog.table_name }
+end


### PR DESCRIPTION
@banukutlu and I made this base class (and shells of subclasses) to store error messages from importers. Ryan will be using this in #188 and Banu will use it in #187. We would like this merged before we start coding up those respective tickets, although we could always branch off this branch too. 