### PR TITLE
Rename Capistrano deployments

### DIFF
--- a/config/deploy/beta.rb
+++ b/config/deploy/beta.rb
@@ -1,8 +1,0 @@
-# Tell capistrano to use the beta environment. This is key for running
-# the database migrations via "cap beta deploy:migrations".
-set :rails_env, "beta"
-
-# The hosts that we're deploying to.
-role :app, "rmdweb1stage.vmhost.psu.edu"
-role :web, "rmdweb1stage.vmhost.psu.edu"
-role :db,  "rmdweb1stage.vmhost.psu.edu", primary: true

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,8 @@
+# Tell capistrano to use the staging environment. This is key for running
+# the database migrations via "cap staging deploy:migrations".
+set :rails_env, "staging"
+
+# The hosts that we're deploying to.
+role :app, "rmdweb1qa.vmhost.psu.edu"
+role :web, "rmdweb1qa.vmhost.psu.edu"
+role :db,  "rmdweb1qa.vmhost.psu.edu", primary: true

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,8 +1,8 @@
-# Tell capistrano to use the staging environment. This is key for running
-# the database migrations via "cap staging deploy:migrations".
-set :rails_env, "staging"
+# Tell capistrano to use the beta environment. This is key for running
+# the database migrations via "cap beta deploy:migrations".
+set :rails_env, "beta"
 
 # The hosts that we're deploying to.
-role :app, "rmdweb1qa.vmhost.psu.edu"
-role :web, "rmdweb1qa.vmhost.psu.edu"
-role :db,  "rmdweb1qa.vmhost.psu.edu", primary: true
+role :app, "rmdweb1stage.vmhost.psu.edu"
+role :web, "rmdweb1stage.vmhost.psu.edu"
+role :db,  "rmdweb1stage.vmhost.psu.edu", primary: true


### PR DESCRIPTION
Bring our Capistrano environment names inline with our servers. QA now corresponds to the qa server, and staging likewise. The Rails environments are unchanged, so there's still a little mismatch there, but the cap commands should match up with our current communication of deployment environments.