### PR TITLE
Revert rubocop changes to migration files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,13 @@ inherit_from: .rubocop_todo.yml
 
 inherit_gem:
   niftany: niftany_rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 2.6
+  Exclude:
+    - 'db/**/*'
+    - 'script/**/*'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+    - 'bin/**/*'
+    - 'node_modules/**/*'

--- a/db/migrate/20180612200031_create_publications.rb
+++ b/db/migrate/20180612200031_create_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreatePublications < ActiveRecord::Migration[5.2]
   def change
     create_table :publications do |t|

--- a/db/migrate/20180630190321_create_people.rb
+++ b/db/migrate/20180630190321_create_people.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreatePeople < ActiveRecord::Migration[5.2]
   def change
     create_table :people do |t|

--- a/db/migrate/20180630191350_create_users.rb
+++ b/db/migrate/20180630191350_create_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|

--- a/db/migrate/20180630193214_create_authorships.rb
+++ b/db/migrate/20180630193214_create_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateAuthorships < ActiveRecord::Migration[5.2]
   def change
     create_table :authorships do |t|

--- a/db/migrate/20180701163339_add_attributes_publications.rb
+++ b/db/migrate/20180701163339_add_attributes_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddAttributesPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :activity_insight_identifier, :string

--- a/db/migrate/20180703204628_add_indexes_for_activity_insight_identifiers.rb
+++ b/db/migrate/20180703204628_add_indexes_for_activity_insight_identifiers.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddIndexesForActivityInsightIdentifiers < ActiveRecord::Migration[5.2]
   def change
     add_index :people, :activity_insight_identifier

--- a/db/migrate/20180706140823_add_index_on_users_webaccess_id.rb
+++ b/db/migrate/20180706140823_add_index_on_users_webaccess_id.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddIndexOnUsersWebaccessId < ActiveRecord::Migration[5.2]
   def change
     add_index :users, :webaccess_id

--- a/db/migrate/20180706141407_add_not_null_constraint_on_users_webaccess_id.rb
+++ b/db/migrate/20180706141407_add_not_null_constraint_on_users_webaccess_id.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddNotNullConstraintOnUsersWebaccessId < ActiveRecord::Migration[5.2]
   def change
     change_column_null :users, :webaccess_id, false

--- a/db/migrate/20180706200842_create_publication_imports.rb
+++ b/db/migrate/20180706200842_create_publication_imports.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreatePublicationImports < ActiveRecord::Migration[5.2]
   def change
     create_table :publication_imports do |t|

--- a/db/migrate/20180706214358_remove_columns_from_publications.rb
+++ b/db/migrate/20180706214358_remove_columns_from_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RemoveColumnsFromPublications < ActiveRecord::Migration[5.2]
   def up
     remove_column :publications, :title

--- a/db/migrate/20180711194629_add_outside_contributors_to_publication_imports.rb
+++ b/db/migrate/20180711194629_add_outside_contributors_to_publication_imports.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddOutsideContributorsToPublicationImports < ActiveRecord::Migration[5.2]
   def change
     add_column :publication_imports, :outside_contributors, :text

--- a/db/migrate/20180711200232_add_user_attributes_to_people.rb
+++ b/db/migrate/20180711200232_add_user_attributes_to_people.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUserAttributesToPeople < ActiveRecord::Migration[5.2]
   def change
     add_column :people, :is_admin, :boolean

--- a/db/migrate/20180711200512_drop_users.rb
+++ b/db/migrate/20180711200512_drop_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class DropUsers < ActiveRecord::Migration[5.2]
   def up
     drop_table :users

--- a/db/migrate/20180711202141_add_db_constraints_to_people.rb
+++ b/db/migrate/20180711202141_add_db_constraints_to_people.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddDbConstraintsToPeople < ActiveRecord::Migration[5.2]
   def change
     change_column_null :people, :webaccess_id, false

--- a/db/migrate/20180711202919_rename_people_to_users.rb
+++ b/db/migrate/20180711202919_rename_people_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RenamePeopleToUsers < ActiveRecord::Migration[5.2]
   def change
     rename_table :people, :users

--- a/db/migrate/20180711203324_rename_person_fk_on_authorship.rb
+++ b/db/migrate/20180711203324_rename_person_fk_on_authorship.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RenamePersonFkOnAuthorship < ActiveRecord::Migration[5.2]
   def up
     remove_foreign_key :authorships, column: :person_id

--- a/db/migrate/20180711205935_add_fields_to_publications.rb
+++ b/db/migrate/20180711205935_add_fields_to_publications.rb
@@ -1,26 +1,24 @@
-# frozen_string_literal: true
-
 class AddFieldsToPublications < ActiveRecord::Migration[5.2]
   def change
     change_table :publications do |t|
-      t.text 'title', null: false
-      t.string 'type', null: false
-      t.text 'journal_title'
-      t.text 'publisher'
-      t.text 'secondary_title'
-      t.string 'status'
-      t.string 'volume'
-      t.string 'issue'
-      t.string 'edition'
-      t.string 'page_range'
-      t.text 'url'
-      t.string 'isbn'
-      t.string 'issn'
-      t.string 'doi'
-      t.text 'abstract'
-      t.boolean 'authors_et_al'
-      t.datetime 'published_at'
-      t.text 'outside_contributors'
+      t.text "title", null: false
+      t.string "type", null: false
+      t.text "journal_title"
+      t.text "publisher"
+      t.text "secondary_title"
+      t.string "status"
+      t.string "volume"
+      t.string "issue"
+      t.string "edition"
+      t.string "page_range"
+      t.text "url"
+      t.string "isbn"
+      t.string "issn"
+      t.string "doi"
+      t.text "abstract"
+      t.boolean "authors_et_al"
+      t.datetime "published_at"
+      t.text "outside_contributors"
     end
   end
 end

--- a/db/migrate/20180711212906_rename_type_in_publications_and_publication_imports.rb
+++ b/db/migrate/20180711212906_rename_type_in_publications_and_publication_imports.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RenameTypeInPublicationsAndPublicationImports < ActiveRecord::Migration[5.2]
   def change
     rename_column :publications, :type, :publication_type

--- a/db/migrate/20180712171822_add_uniqueness_constraint_to_webaccess_id_index.rb
+++ b/db/migrate/20180712171822_add_uniqueness_constraint_to_webaccess_id_index.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUniquenessConstraintToWebaccessIdIndex < ActiveRecord::Migration[5.2]
   def up
     remove_index :users, :webaccess_id

--- a/db/migrate/20180712173855_add_uniqueness_constraint_to_activity_insight_id_index.rb
+++ b/db/migrate/20180712173855_add_uniqueness_constraint_to_activity_insight_id_index.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUniquenessConstraintToActivityInsightIdIndex < ActiveRecord::Migration[5.2]
   def up
     remove_index :users, :activity_insight_identifier

--- a/db/migrate/20180712211349_add_not_null_constraints_to_foreign_keys_on_authorships.rb
+++ b/db/migrate/20180712211349_add_not_null_constraints_to_foreign_keys_on_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddNotNullConstraintsToForeignKeysOnAuthorships < ActiveRecord::Migration[5.2]
   def change
     change_column_null :authorships, :user_id, false

--- a/db/migrate/20180713191323_create_contributor_imports.rb
+++ b/db/migrate/20180713191323_create_contributor_imports.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateContributorImports < ActiveRecord::Migration[5.2]
   def change
     create_table :contributor_imports do |t|

--- a/db/migrate/20180713192156_create_contributors.rb
+++ b/db/migrate/20180713192156_create_contributors.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateContributors < ActiveRecord::Migration[5.2]
   def change
     create_table :contributors do |t|

--- a/db/migrate/20180713192758_remove_outside_contributors_from_publications.rb
+++ b/db/migrate/20180713192758_remove_outside_contributors_from_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RemoveOutsideContributorsFromPublications < ActiveRecord::Migration[5.2]
   def up
     remove_column :publications, :outside_contributors

--- a/db/migrate/20180717152523_add_source_information_to_contributor_imports.rb
+++ b/db/migrate/20180717152523_add_source_information_to_contributor_imports.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddSourceInformationToContributorImports < ActiveRecord::Migration[5.2]
   def change
     add_column :contributor_imports, :import_source, :string, null: false

--- a/db/migrate/20180717154955_add_indexes_for_contributor_import_source_information.rb
+++ b/db/migrate/20180717154955_add_indexes_for_contributor_import_source_information.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddIndexesForContributorImportSourceInformation < ActiveRecord::Migration[5.2]
   def change
     add_index :contributor_imports, :import_source

--- a/db/migrate/20180719185331_add_pure_uuid_to_users.rb
+++ b/db/migrate/20180719185331_add_pure_uuid_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddPureUuidToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :pure_uuid, :string

--- a/db/migrate/20180719212117_add_unique_index_to_authorships_activity_insight_identifier.rb
+++ b/db/migrate/20180719212117_add_unique_index_to_authorships_activity_insight_identifier.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUniqueIndexToAuthorshipsActivityInsightIdentifier < ActiveRecord::Migration[5.2]
   def change
     add_index :authorships, :activity_insight_identifier, unique: true

--- a/db/migrate/20180725140017_change_published_column_types.rb
+++ b/db/migrate/20180725140017_change_published_column_types.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangePublishedColumnTypes < ActiveRecord::Migration[5.2]
   def change
     change_column :publication_imports, :published_at, :date

--- a/db/migrate/20180726174605_add_confidential_column_to_publication_imports.rb
+++ b/db/migrate/20180726174605_add_confidential_column_to_publication_imports.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddConfidentialColumnToPublicationImports < ActiveRecord::Migration[5.2]
   def change
     add_column :publication_imports, :confidential, :boolean, default: false

--- a/db/migrate/20180726175517_add_citation_count_to_publications.rb
+++ b/db/migrate/20180726175517_add_citation_count_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddCitationCountToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publication_imports, :citation_count, :integer

--- a/db/migrate/20180726175826_add_pure_identifier_to_authorships.rb
+++ b/db/migrate/20180726175826_add_pure_identifier_to_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddPureIdentifierToAuthorships < ActiveRecord::Migration[5.2]
   def change
     add_column :authorships, :pure_identifier, :string

--- a/db/migrate/20180727134636_add_penn_state_id_to_users.rb
+++ b/db/migrate/20180727134636_add_penn_state_id_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddPennStateIdToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :penn_state_identifier, :string

--- a/db/migrate/20180731135541_remove_confidential_column_from_publication_imports.rb
+++ b/db/migrate/20180731135541_remove_confidential_column_from_publication_imports.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RemoveConfidentialColumnFromPublicationImports < ActiveRecord::Migration[5.2]
   def up
     remove_column :publication_imports, :confidential

--- a/db/migrate/20180731155905_change_user_foreign_key_on_authorships.rb
+++ b/db/migrate/20180731155905_change_user_foreign_key_on_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangeUserForeignKeyOnAuthorships < ActiveRecord::Migration[5.2]
   def change
     remove_foreign_key :authorships, :users

--- a/db/migrate/20180731160421_change_publications_foreign_key_on_authorships.rb
+++ b/db/migrate/20180731160421_change_publications_foreign_key_on_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangePublicationsForeignKeyOnAuthorships < ActiveRecord::Migration[5.2]
   def change
     remove_foreign_key :authorships, :publications

--- a/db/migrate/20180731161101_change_publications_foreign_key_on_contributors.rb
+++ b/db/migrate/20180731161101_change_publications_foreign_key_on_contributors.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangePublicationsForeignKeyOnContributors < ActiveRecord::Migration[5.2]
   def change
     remove_foreign_key :contributors, :publications

--- a/db/migrate/20180801154447_drop_publication_and_contributor_import_tables.rb
+++ b/db/migrate/20180801154447_drop_publication_and_contributor_import_tables.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class DropPublicationAndContributorImportTables < ActiveRecord::Migration[5.2]
   def change
     remove_foreign_key :publication_imports, :publications

--- a/db/migrate/20180801161232_add_pure_and_activity_insight_ids_to_publications.rb
+++ b/db/migrate/20180801161232_add_pure_and_activity_insight_ids_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddPureAndActivityInsightIdsToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :pure_uuid, :string

--- a/db/migrate/20180801201046_add_pure_and_activity_insight_identifiers_to_contributors.rb
+++ b/db/migrate/20180801201046_add_pure_and_activity_insight_identifiers_to_contributors.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddPureAndActivityInsightIdentifiersToContributors < ActiveRecord::Migration[5.2]
   def change
     add_column :contributors, :pure_identifier, :string

--- a/db/migrate/20180801211629_add_pure_updated_at_timestamp_to_publications.rb
+++ b/db/migrate/20180801211629_add_pure_updated_at_timestamp_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddPureUpdatedAtTimestampToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :pure_updated_at, :datetime

--- a/db/migrate/20180803205629_recreate_publication_imports.rb
+++ b/db/migrate/20180803205629_recreate_publication_imports.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RecreatePublicationImports < ActiveRecord::Migration[5.2]
   def change
     create_table :publication_imports do |t|

--- a/db/migrate/20180807213213_remove_import_columns_from_publications_authorships_and_contributors.rb
+++ b/db/migrate/20180807213213_remove_import_columns_from_publications_authorships_and_contributors.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RemoveImportColumnsFromPublicationsAuthorshipsAndContributors < ActiveRecord::Migration[5.2]
   def change
     remove_column :publications, :pure_uuid

--- a/db/migrate/20180808142314_remove_institution_from_users.rb
+++ b/db/migrate/20180808142314_remove_institution_from_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RemoveInstitutionFromUsers < ActiveRecord::Migration[5.2]
   def change
     remove_column :users, :institution

--- a/db/migrate/20180808214849_create_duplicate_publication_groups.rb
+++ b/db/migrate/20180808214849_create_duplicate_publication_groups.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateDuplicatePublicationGroups < ActiveRecord::Migration[5.2]
   def change
     create_table :duplicate_publication_groups do |t|

--- a/db/migrate/20180808215350_add_duplicate_group_foreign_key_to_publications.rb
+++ b/db/migrate/20180808215350_add_duplicate_group_foreign_key_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddDuplicateGroupForeignKeyToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :duplicate_publication_group_id, :integer

--- a/db/migrate/20180809160107_remove_unneeded_columns_from_duplicate_publication_groups.rb
+++ b/db/migrate/20180809160107_remove_unneeded_columns_from_duplicate_publication_groups.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RemoveUnneededColumnsFromDuplicatePublicationGroups < ActiveRecord::Migration[5.2]
   def change
     remove_column :duplicate_publication_groups, :title

--- a/db/migrate/20180809192512_add_indexes_on_publications.rb
+++ b/db/migrate/20180809192512_add_indexes_on_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddIndexesOnPublications < ActiveRecord::Migration[5.2]
   def change
     add_index :publications, :volume

--- a/db/migrate/20180810152350_add_updated_by_user_at_column_to_users.rb
+++ b/db/migrate/20180810152350_add_updated_by_user_at_column_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUpdatedByUserAtColumnToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :updated_by_user_at, :datetime

--- a/db/migrate/20180814152607_add_unique_index_on_penn_state_identifier_for_users.rb
+++ b/db/migrate/20180814152607_add_unique_index_on_penn_state_identifier_for_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUniqueIndexOnPennStateIdentifierForUsers < ActiveRecord::Migration[5.2]
   def change
     add_index :users, :penn_state_identifier, unique: true

--- a/db/migrate/20180815212507_add_updated_by_user_at_timestamp_to_publications.rb
+++ b/db/migrate/20180815212507_add_updated_by_user_at_timestamp_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUpdatedByUserAtTimestampToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :updated_by_user_at, :datetime

--- a/db/migrate/20180818141756_create_tags.rb
+++ b/db/migrate/20180818141756_create_tags.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateTags < ActiveRecord::Migration[5.2]
   def change
     create_table :tags do |t|

--- a/db/migrate/20180818143045_create_publication_taggings.rb
+++ b/db/migrate/20180818143045_create_publication_taggings.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreatePublicationTaggings < ActiveRecord::Migration[5.2]
   def change
     create_table :publication_taggings do |t|

--- a/db/migrate/20180820205334_change_rank_column_type.rb
+++ b/db/migrate/20180820205334_change_rank_column_type.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangeRankColumnType < ActiveRecord::Migration[5.2]
   def change
     change_column :publication_taggings, :rank, :float

--- a/db/migrate/20180830201444_remove_title_column_from_users.rb
+++ b/db/migrate/20180830201444_remove_title_column_from_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RemoveTitleColumnFromUsers < ActiveRecord::Migration[5.2]
   def up
     remove_column :users, :title

--- a/db/migrate/20180830203141_add_visible_column_to_publications.rb
+++ b/db/migrate/20180830203141_add_visible_column_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddVisibleColumnToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :visible, :boolean, default: false

--- a/db/migrate/20180906185322_create_etds.rb
+++ b/db/migrate/20180906185322_create_etds.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateEtds < ActiveRecord::Migration[5.2]
   def change
     create_table :etds do |t|

--- a/db/migrate/20180906190755_create_committee_memberships.rb
+++ b/db/migrate/20180906190755_create_committee_memberships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateCommitteeMemberships < ActiveRecord::Migration[5.2]
   def change
     create_table :committee_memberships do |t|

--- a/db/migrate/20180917134014_create_contracts.rb
+++ b/db/migrate/20180917134014_create_contracts.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateContracts < ActiveRecord::Migration[5.2]
   def change
     create_table :contracts do |t|

--- a/db/migrate/20180917134130_create_contract_imports.rb
+++ b/db/migrate/20180917134130_create_contract_imports.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateContractImports < ActiveRecord::Migration[5.2]
   def change
     create_table :contract_imports do |t|

--- a/db/migrate/20180917134245_create_user_contracts.rb
+++ b/db/migrate/20180917134245_create_user_contracts.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateUserContracts < ActiveRecord::Migration[5.2]
   def change
     create_table :user_contracts do |t|

--- a/db/migrate/20180917144515_change_contract_import_column_type.rb
+++ b/db/migrate/20180917144515_change_contract_import_column_type.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangeContractImportColumnType < ActiveRecord::Migration[5.2]
   def change
     change_column :contract_imports, :activity_insight_id, :bigint

--- a/db/migrate/20180917152432_change_contract_contraints.rb
+++ b/db/migrate/20180917152432_change_contract_contraints.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangeContractContraints < ActiveRecord::Migration[5.2]
   def change
     change_column_null :contracts, :award_start_on, true

--- a/db/migrate/20180917175612_add_uniqueness_to_etds_indices.rb
+++ b/db/migrate/20180917175612_add_uniqueness_to_etds_indices.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUniquenessToEtdsIndices < ActiveRecord::Migration[5.2]
   def up
     remove_index :etds, :webaccess_id

--- a/db/migrate/20180917185209_add_updated_by_user_at_column_to_etds.rb
+++ b/db/migrate/20180917185209_add_updated_by_user_at_column_to_etds.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUpdatedByUserAtColumnToEtds < ActiveRecord::Migration[5.2]
   def change
     add_column :etds, :updated_by_user_at, :datetime

--- a/db/migrate/20180926183431_create_news_feed_items.rb
+++ b/db/migrate/20180926183431_create_news_feed_items.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateNewsFeedItems < ActiveRecord::Migration[5.2]
   def change
     create_table :news_feed_items do |t|

--- a/db/migrate/20181003153328_add_pubdate_column_to_news_feed_items.rb
+++ b/db/migrate/20181003153328_add_pubdate_column_to_news_feed_items.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddPubdateColumnToNewsFeedItems < ActiveRecord::Migration[5.2]
   def change
     add_column :news_feed_items, :pubdate, :date, null: false

--- a/db/migrate/20181004184801_add_visibility_flag_to_contracts.rb
+++ b/db/migrate/20181004184801_add_visibility_flag_to_contracts.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddVisibilityFlagToContracts < ActiveRecord::Migration[5.2]
   def change
     add_column :contracts, :visible, :boolean, default: false

--- a/db/migrate/20181005194413_create_presentations.rb
+++ b/db/migrate/20181005194413_create_presentations.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreatePresentations < ActiveRecord::Migration[5.2]
   def change
     create_table :presentations do |t|

--- a/db/migrate/20181005213438_add_unique_index_on_presentations_activity_insight_identifier.rb
+++ b/db/migrate/20181005213438_add_unique_index_on_presentations_activity_insight_identifier.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUniqueIndexOnPresentationsActivityInsightIdentifier < ActiveRecord::Migration[5.2]
   def change
     add_index :presentations, :activity_insight_identifier, unique: true

--- a/db/migrate/20181009150634_remove_null_constraint_on_presentation_title.rb
+++ b/db/migrate/20181009150634_remove_null_constraint_on_presentation_title.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RemoveNullConstraintOnPresentationTitle < ActiveRecord::Migration[5.2]
   def change
     change_column_null :presentations, :title, true

--- a/db/migrate/20181009154455_rename_presentations_type_column.rb
+++ b/db/migrate/20181009154455_rename_presentations_type_column.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RenamePresentationsTypeColumn < ActiveRecord::Migration[5.2]
   def change
     rename_column :presentations, :type, :presentation_type

--- a/db/migrate/20181010161558_add_null_constraint_to_presentations_activity_insight_identifier.rb
+++ b/db/migrate/20181010161558_add_null_constraint_to_presentations_activity_insight_identifier.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddNullConstraintToPresentationsActivityInsightIdentifier < ActiveRecord::Migration[5.2]
   def change
     change_column_null :presentations, :activity_insight_identifier, false

--- a/db/migrate/20181017135932_create_organizations.rb
+++ b/db/migrate/20181017135932_create_organizations.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateOrganizations < ActiveRecord::Migration[5.2]
   def change
     create_table :organizations do |t|

--- a/db/migrate/20181017155638_rename_organizations_type_column.rb
+++ b/db/migrate/20181017155638_rename_organizations_type_column.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RenameOrganizationsTypeColumn < ActiveRecord::Migration[5.2]
   def change
     rename_column :organizations, :type, :organization_type

--- a/db/migrate/20181017215146_create_presentation_contributions.rb
+++ b/db/migrate/20181017215146_create_presentation_contributions.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreatePresentationContributions < ActiveRecord::Migration[5.2]
   def change
     create_table :presentation_contributions do |t|

--- a/db/migrate/20181024164002_create_performances.rb
+++ b/db/migrate/20181024164002_create_performances.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreatePerformances < ActiveRecord::Migration[5.2]
   def change
     create_table :performances do |t|

--- a/db/migrate/20181024181925_create_user_performances.rb
+++ b/db/migrate/20181024181925_create_user_performances.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateUserPerformances < ActiveRecord::Migration[5.2]
   def change
     create_table :user_performances do |t|

--- a/db/migrate/20181024183722_change_performance_columns.rb
+++ b/db/migrate/20181024183722_change_performance_columns.rb
@@ -1,8 +1,6 @@
-# frozen_string_literal: true
-
 class ChangePerformanceColumns < ActiveRecord::Migration[5.2]
   def change
-    remove_index :performances, name: 'index_performances_on_activity_insight_id'
+    remove_index :performances, name: "index_performances_on_activity_insight_id"
     remove_column :performances, :activity_insight_id
     add_column :performances, :visible, :boolean, default: false
   end

--- a/db/migrate/20181025143054_create_performance_import.rb
+++ b/db/migrate/20181025143054_create_performance_import.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreatePerformanceImport < ActiveRecord::Migration[5.2]
   def change
     create_table :performance_imports do |t|

--- a/db/migrate/20181025163933_change_news_feed_items_pubdate_column.rb
+++ b/db/migrate/20181025163933_change_news_feed_items_pubdate_column.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangeNewsFeedItemsPubdateColumn < ActiveRecord::Migration[5.2]
   def change
     rename_column :news_feed_items, :pubdate, :published_on

--- a/db/migrate/20181031202845_create_user_organization_memberships.rb
+++ b/db/migrate/20181031202845_create_user_organization_memberships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateUserOrganizationMemberships < ActiveRecord::Migration[5.2]
   def change
     create_table :user_organization_memberships do |t|

--- a/db/migrate/20181101173943_add_start_and_end_dates_to_user_organization_memberships.rb
+++ b/db/migrate/20181101173943_add_start_and_end_dates_to_user_organization_memberships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddStartAndEndDatesToUserOrganizationMemberships < ActiveRecord::Migration[5.2]
   def change
     add_column :user_organization_memberships, :started_on, :date

--- a/db/migrate/20181105192424_add_activity_insight_id_to_performances.rb
+++ b/db/migrate/20181105192424_add_activity_insight_id_to_performances.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddActivityInsightIdToPerformances < ActiveRecord::Migration[5.2]
   def change
     add_column :performances, :activity_insight_id, :bigint, null: false

--- a/db/migrate/20181105194951_drop_publication_imports_table.rb
+++ b/db/migrate/20181105194951_drop_publication_imports_table.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class DropPublicationImportsTable < ActiveRecord::Migration[5.2]
   def change
     remove_foreign_key :performance_imports, :performances

--- a/db/migrate/20181105201412_add_unique_index_on_activity_insight_id_for_performances.rb
+++ b/db/migrate/20181105201412_add_unique_index_on_activity_insight_id_for_performances.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUniqueIndexOnActivityInsightIdForPerformances < ActiveRecord::Migration[5.2]
   def change
     add_index :performances, :activity_insight_id, unique: true

--- a/db/migrate/20181115162039_add_owner_id_to_organizations.rb
+++ b/db/migrate/20181115162039_add_owner_id_to_organizations.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddOwnerIdToOrganizations < ActiveRecord::Migration[5.2]
   def change
     add_column :organizations, :owner_id, :integer

--- a/db/migrate/20181115214959_add_publication_visibility_field_to_users.rb
+++ b/db/migrate/20181115214959_add_publication_visibility_field_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddPublicationVisibilityFieldToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :show_all_publications, :boolean

--- a/db/migrate/20181115220546_set_default_value_for_user_publication_visibility.rb
+++ b/db/migrate/20181115220546_set_default_value_for_user_publication_visibility.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class SetDefaultValueForUserPublicationVisibility < ActiveRecord::Migration[5.2]
   def change
     change_column_default :users, :show_all_publications, false

--- a/db/migrate/20181116181925_add_contract_visibility_flag_to_users.rb
+++ b/db/migrate/20181116181925_add_contract_visibility_flag_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddContractVisibilityFlagToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :show_all_contracts, :boolean, default: false

--- a/db/migrate/20181116193029_add_scopus_h_index_column_to_users.rb
+++ b/db/migrate/20181116193029_add_scopus_h_index_column_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddScopusHIndexColumnToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :scopus_h_index, :integer

--- a/db/migrate/20181116213428_rename_citation_count_on_publications.rb
+++ b/db/migrate/20181116213428_rename_citation_count_on_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RenameCitationCountOnPublications < ActiveRecord::Migration[5.2]
   def change
     rename_column :publications, :citation_count, :total_scopus_citations

--- a/db/migrate/20181119173631_remove_type_other_column_from_performances.rb
+++ b/db/migrate/20181119173631_remove_type_other_column_from_performances.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RemoveTypeOtherColumnFromPerformances < ActiveRecord::Migration[5.2]
   def change
     remove_column :performances, :type_other

--- a/db/migrate/20181120152538_add_contribution_student_level_and_role_other_to_user_performances.rb
+++ b/db/migrate/20181120152538_add_contribution_student_level_and_role_other_to_user_performances.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddContributionStudentLevelAndRoleOtherToUserPerformances < ActiveRecord::Migration[5.2]
   def change
     add_column :user_performances, :contribution, :string

--- a/db/migrate/20181130155757_create_api_tokens.rb
+++ b/db/migrate/20181130155757_create_api_tokens.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateAPITokens < ActiveRecord::Migration[5.2]
   def change
     create_table :api_tokens do |t|

--- a/db/migrate/20181130164944_create_performance_screenings.rb
+++ b/db/migrate/20181130164944_create_performance_screenings.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreatePerformanceScreenings < ActiveRecord::Migration[5.2]
   def change
     create_table :performance_screenings do |t|

--- a/db/migrate/20181204145338_add_usage_tracking_columns_to_api_tokens.rb
+++ b/db/migrate/20181204145338_add_usage_tracking_columns_to_api_tokens.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUsageTrackingColumnsToAPITokens < ActiveRecord::Migration[5.2]
   def change
     add_column :api_tokens, :total_requests, :integer, default: 0

--- a/db/migrate/20181205173137_add_activity_insight_id_column_to_user_performances.rb
+++ b/db/migrate/20181205173137_add_activity_insight_id_column_to_user_performances.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddActivityInsightIdColumnToUserPerformances < ActiveRecord::Migration[5.2]
   def change
     add_column :user_performances, :activity_insight_id, :integer

--- a/db/migrate/20181205175509_change_user_performance_column_activity_insight_id.rb
+++ b/db/migrate/20181205175509_change_user_performance_column_activity_insight_id.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangeUserPerformanceColumnActivityInsightId < ActiveRecord::Migration[5.2]
   def change
     change_column_null :user_performances, :activity_insight_id, false

--- a/db/migrate/20181205191546_add_activity_insight_id_column_to_performance_screenings.rb
+++ b/db/migrate/20181205191546_add_activity_insight_id_column_to_performance_screenings.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddActivityInsightIdColumnToPerformanceScreenings < ActiveRecord::Migration[5.2]
   def change
     add_column :performance_screenings, :activity_insight_id, :bigint, null: false

--- a/db/migrate/20181207154400_add_contact_and_bio_information_columns_to_users.rb
+++ b/db/migrate/20181207154400_add_contact_and_bio_information_columns_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddContactAndBioInformationColumnsToUsers < ActiveRecord::Migration[5.2]
   def change
     change_table :users do |t|

--- a/db/migrate/20181212152125_add_google_scholar_column_to_users.rb
+++ b/db/migrate/20181212152125_add_google_scholar_column_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddGoogleScholarColumnToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :ai_google_scholar, :text

--- a/db/migrate/20190312202708_create_education_history_items.rb
+++ b/db/migrate/20190312202708_create_education_history_items.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateEducationHistoryItems < ActiveRecord::Migration[5.2]
   def change
     create_table :education_history_items do |t|

--- a/db/migrate/20190313151201_add_index_on_eduction_history_items_activity_insight_identifier.rb
+++ b/db/migrate/20190313151201_add_index_on_eduction_history_items_activity_insight_identifier.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddIndexOnEductionHistoryItemsActivityInsightIdentifier < ActiveRecord::Migration[5.2]
   def change
     add_index :education_history_items, :activity_insight_identifier, unique: true

--- a/db/migrate/20190701171414_add_visibility_column_to_authorships.rb
+++ b/db/migrate/20190701171414_add_visibility_column_to_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddVisibilityColumnToAuthorships < ActiveRecord::Migration[5.2]
   def change
     add_column :authorships, :visible_in_profile, :boolean

--- a/db/migrate/20190701181430_add_default_to_authorships_visible_in_profile_column.rb
+++ b/db/migrate/20190701181430_add_default_to_authorships_visible_in_profile_column.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddDefaultToAuthorshipsVisibleInProfileColumn < ActiveRecord::Migration[5.2]
   def change
     change_column :authorships, :visible_in_profile, :boolean, default: true

--- a/db/migrate/20190702130930_add_position_column_to_authorships.rb
+++ b/db/migrate/20190702130930_add_position_column_to_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddPositionColumnToAuthorships < ActiveRecord::Migration[5.2]
   def change
     add_column :authorships, :position_in_profile, :integer

--- a/db/migrate/20190711143519_add_profile_preference_columns_to_presentation_conributions.rb
+++ b/db/migrate/20190711143519_add_profile_preference_columns_to_presentation_conributions.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddProfilePreferenceColumnsToPresentationConributions < ActiveRecord::Migration[5.2]
   def change
     add_column :presentation_contributions, :visible_in_profile, :boolean, default: true

--- a/db/migrate/20190711183740_add_profile_preference_columns_to_user_performances_table.rb
+++ b/db/migrate/20190711183740_add_profile_preference_columns_to_user_performances_table.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddProfilePreferenceColumnsToUserPerformancesTable < ActiveRecord::Migration[5.2]
   def change
     add_column :user_performances, :visible_in_profile, :boolean, default: true

--- a/db/migrate/20190814193511_create_organization_api_permissions.rb
+++ b/db/migrate/20190814193511_create_organization_api_permissions.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateOrganizationAPIPermissions < ActiveRecord::Migration[5.2]
   def change
     create_table :organization_api_permissions do |t|

--- a/db/migrate/20190816141555_change_default_visibility_values.rb
+++ b/db/migrate/20190816141555_change_default_visibility_values.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangeDefaultVisibilityValues < ActiveRecord::Migration[5.2]
   def change
     change_column_default :performances, :visible, from: false, to: true

--- a/db/migrate/20190830192733_add_indexes_to_users_table.rb
+++ b/db/migrate/20190830192733_add_indexes_to_users_table.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddIndexesToUsersTable < ActiveRecord::Migration[5.2]
   def change
     add_index :users, :orcid_identifier, unique: true

--- a/db/migrate/20190830193401_add_index_on_publications_doi.rb
+++ b/db/migrate/20190830193401_add_index_on_publications_doi.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddIndexOnPublicationsDOI < ActiveRecord::Migration[5.2]
   def change
     add_index :publications, :doi

--- a/db/migrate/20190830200139_create_grants.rb
+++ b/db/migrate/20190830200139_create_grants.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateGrants < ActiveRecord::Migration[5.2]
   def change
     create_table :grants do |t|

--- a/db/migrate/20190830200901_create_research_funds.rb
+++ b/db/migrate/20190830200901_create_research_funds.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateResearchFunds < ActiveRecord::Migration[5.2]
   def change
     create_table :research_funds do |t|

--- a/db/migrate/20190911131305_add_confirmed_column_to_authorships.rb
+++ b/db/migrate/20190911131305_add_confirmed_column_to_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddConfirmedColumnToAuthorships < ActiveRecord::Migration[5.2]
   def change
     add_column :authorships, :confirmed, :boolean, default: true

--- a/db/migrate/20190911164635_add_columns_to_grants_table.rb
+++ b/db/migrate/20190911164635_add_columns_to_grants_table.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddColumnsToGrantsTable < ActiveRecord::Migration[5.2]
   def change
     add_column :grants, :title, :text

--- a/db/migrate/20190911175932_create_researcher_funds_table.rb
+++ b/db/migrate/20190911175932_create_researcher_funds_table.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateResearcherFundsTable < ActiveRecord::Migration[5.2]
   def change
     create_table :researcher_funds do |t|

--- a/db/migrate/20190913141112_rename_columns_in_grants_table.rb
+++ b/db/migrate/20190913141112_rename_columns_in_grants_table.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RenameColumnsInGrantsTable < ActiveRecord::Migration[5.2]
   def change
     rename_column :grants, :agency_name, :wos_agency_name

--- a/db/migrate/20190913143857_add_index_on_wos_agency_in_grants_table.rb
+++ b/db/migrate/20190913143857_add_index_on_wos_agency_in_grants_table.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddIndexOnWOSAgencyInGrantsTable < ActiveRecord::Migration[5.2]
   def change
     add_index :grants, :wos_agency_name

--- a/db/migrate/20190913150714_change_null_constraint_on_grants_wos_agency_name.rb
+++ b/db/migrate/20190913150714_change_null_constraint_on_grants_wos_agency_name.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangeNullConstraintOnGrantsWOSAgencyName < ActiveRecord::Migration[5.2]
   def change
     change_column_null :grants, :wos_agency_name, true

--- a/db/migrate/20190913151958_add_new_identifier_columns_to_grants_table.rb
+++ b/db/migrate/20190913151958_add_new_identifier_columns_to_grants_table.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddNewIdentifierColumnsToGrantsTable < ActiveRecord::Migration[5.2]
   def change
     add_column :grants, :identifier, :string

--- a/db/migrate/20191108165421_add_open_access_url_to_publications.rb
+++ b/db/migrate/20191108165421_add_open_access_url_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddOpenAccessUrlToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :open_access_url, :text

--- a/db/migrate/20191113142315_add_open_access_button_timestamp_to_publications.rb
+++ b/db/migrate/20191113142315_add_open_access_button_timestamp_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddOpenAccessButtonTimestampToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :open_access_button_last_checked_at, :datetime

--- a/db/migrate/20191115202327_add_user_submitted_open_access_url_to_publications.rb
+++ b/db/migrate/20191115202327_add_user_submitted_open_access_url_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUserSubmittedOpenAccessUrlToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :user_submitted_open_access_url, :text

--- a/db/migrate/20191206215734_add_scholarsphere_upload_timestamp_to_authorships.rb
+++ b/db/migrate/20191206215734_add_scholarsphere_upload_timestamp_to_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddScholarsphereUploadTimestampToAuthorships < ActiveRecord::Migration[5.2]
   def change
     add_column :authorships, :scholarsphere_uploaded_at, :datetime

--- a/db/migrate/20191211163942_create_internal_publication_waivers_table.rb
+++ b/db/migrate/20191211163942_create_internal_publication_waivers_table.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateInternalPublicationWaiversTable < ActiveRecord::Migration[5.2]
   def change
     create_table :internal_publication_waivers do |t|

--- a/db/migrate/20191218212329_create_external_publication_waivers.rb
+++ b/db/migrate/20191218212329_create_external_publication_waivers.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateExternalPublicationWaivers < ActiveRecord::Migration[5.2]
   def change
     create_table :external_publication_waivers do |t|

--- a/db/migrate/20191219170847_change_news_feed_item_index.rb
+++ b/db/migrate/20191219170847_change_news_feed_item_index.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangeNewsFeedItemIndex < ActiveRecord::Migration[5.2]
   def change
     remove_index :news_feed_items, :url

--- a/db/migrate/20200113181629_add_pg_trgm_extension.rb
+++ b/db/migrate/20200113181629_add_pg_trgm_extension.rb
@@ -1,7 +1,5 @@
-# frozen_string_literal: true
-
 class AddPgTrgmExtension < ActiveRecord::Migration[5.2]
   def change
-    enable_extension 'pg_trgm'
+    enable_extension "pg_trgm"
   end
 end

--- a/db/migrate/20200211180255_add_role_columns_to_authorships_and_contributors.rb
+++ b/db/migrate/20200211180255_add_role_columns_to_authorships_and_contributors.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddRoleColumnsToAuthorshipsAndContributors < ActiveRecord::Migration[5.2]
   def change
     add_column :authorships, :role, :string

--- a/db/migrate/20200218223334_add_orcid_access_token_to_users.rb
+++ b/db/migrate/20200218223334_add_orcid_access_token_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddOrcidAccessTokenToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :orcid_access_token, :string

--- a/db/migrate/20200519201649_add_orcid_resource_identifier_to_user_organization_memberships.rb
+++ b/db/migrate/20200519201649_add_orcid_resource_identifier_to_user_organization_memberships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddOrcidResourceIdentifierToUserOrganizationMemberships < ActiveRecord::Migration[5.2]
   def change
     add_column :user_organization_memberships, :orcid_resource_identifier, :string

--- a/db/migrate/20200521212347_add_orcid_authorization_fields_to_users.rb
+++ b/db/migrate/20200521212347_add_orcid_authorization_fields_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddOrcidAuthorizationFieldsToUsers < ActiveRecord::Migration[5.2]
   def change
     change_table :users do |t|

--- a/db/migrate/20200605150305_add_open_access_notification_timestamp_to_users.rb
+++ b/db/migrate/20200605150305_add_open_access_notification_timestamp_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddOpenAccessNotificationTimestampToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :open_access_notification_sent_at, :datetime

--- a/db/migrate/20200616183430_add_open_access_notification_timestamp_to_authorships.rb
+++ b/db/migrate/20200616183430_add_open_access_notification_timestamp_to_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddOpenAccessNotificationTimestampToAuthorships < ActiveRecord::Migration[5.2]
   def change
     add_column :authorships, :open_access_notification_sent_at, :datetime

--- a/db/migrate/20200624193001_add_internal_waiver_foreign_key_to_external_waivers.rb
+++ b/db/migrate/20200624193001_add_internal_waiver_foreign_key_to_external_waivers.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddInternalWaiverForeignKeyToExternalWaivers < ActiveRecord::Migration[5.2]
   def change
     add_column :external_publication_waivers, :internal_publication_waiver_id, :integer

--- a/db/migrate/20200626171646_create_non_duplicate_publication_groups.rb
+++ b/db/migrate/20200626171646_create_non_duplicate_publication_groups.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateNonDuplicatePublicationGroups < ActiveRecord::Migration[5.2]
   def change
     create_table :non_duplicate_publication_groups do |t|

--- a/db/migrate/20200626172547_add_non_duplicate_group_foreign_key_to_publications.rb
+++ b/db/migrate/20200626172547_add_non_duplicate_group_foreign_key_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddNonDuplicateGroupForeignKeyToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :non_duplicate_publication_group_id, :integer

--- a/db/migrate/20200626185838_drop_non_duplicate_group_foreign_key_from_publications.rb
+++ b/db/migrate/20200626185838_drop_non_duplicate_group_foreign_key_from_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class DropNonDuplicateGroupForeignKeyFromPublications < ActiveRecord::Migration[5.2]
   def change
     remove_foreign_key :publications,

--- a/db/migrate/20200626191346_create_non_duplicate_publication_group_memberships.rb
+++ b/db/migrate/20200626191346_create_non_duplicate_publication_group_memberships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateNonDuplicatePublicationGroupMemberships < ActiveRecord::Migration[5.2]
   def change
     create_table :non_duplicate_publication_group_memberships do |t|

--- a/db/migrate/20200717152829_add_orcid_resource_identifier_to_authorships.rb
+++ b/db/migrate/20200717152829_add_orcid_resource_identifier_to_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddOrcidResourceIdentifierToAuthorships < ActiveRecord::Migration[5.2]
   def change
     add_column :authorships, :orcid_resource_identifier, :string

--- a/db/migrate/20200807195118_add_indices_to_publications.rb
+++ b/db/migrate/20200807195118_add_indices_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddIndicesToPublications < ActiveRecord::Migration[5.2]
   def up
     add_index :publications, :published_on

--- a/db/migrate/20200903220756_remove_imported_from_pure_column_from_user_organization_memberships.rb
+++ b/db/migrate/20200903220756_remove_imported_from_pure_column_from_user_organization_memberships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RemoveImportedFromPureColumnFromUserOrganizationMemberships < ActiveRecord::Migration[5.2]
   def up
     remove_column :user_organization_memberships, :imported_from_pure

--- a/db/migrate/20200904170213_rename_pure_identifier_to_source_identifier_on_user_organization_memberships.rb
+++ b/db/migrate/20200904170213_rename_pure_identifier_to_source_identifier_on_user_organization_memberships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RenamePureIdentifierToSourceIdentifierOnUserOrganizationMemberships < ActiveRecord::Migration[5.2]
   def up
     remove_index :user_organization_memberships, :pure_identifier

--- a/db/migrate/20200904171117_add_import_source_to_user_organization_memberships.rb
+++ b/db/migrate/20200904171117_add_import_source_to_user_organization_memberships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddImportSourceToUserOrganizationMemberships < ActiveRecord::Migration[5.2]
   def change
     add_column :user_organization_memberships, :import_source, :string

--- a/db/migrate/20201027175708_add_auto_merge_flag_to_publication_imports.rb
+++ b/db/migrate/20201027175708_add_auto_merge_flag_to_publication_imports.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddAutoMergeFlagToPublicationImports < ActiveRecord::Migration[5.2]
   def change
     add_column :publication_imports, :auto_merged, :boolean

--- a/db/migrate/20201111183613_create_delayed_jobs.rb
+++ b/db/migrate/20201111183613_create_delayed_jobs.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateDelayedJobs < ActiveRecord::Migration[5.2]
   def self.up
     create_table :delayed_jobs, force: true do |table|
@@ -15,7 +13,7 @@ class CreateDelayedJobs < ActiveRecord::Migration[5.2]
       table.timestamps null: true
     end
 
-    add_index :delayed_jobs, [:priority, :run_at], name: 'delayed_jobs_priority'
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
   end
 
   def self.down

--- a/db/migrate/20201203151246_create_journals.rb
+++ b/db/migrate/20201203151246_create_journals.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateJournals < ActiveRecord::Migration[5.2]
   def change
     create_table :journals do |t|

--- a/db/migrate/20201203153413_create_publishers.rb
+++ b/db/migrate/20201203153413_create_publishers.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreatePublishers < ActiveRecord::Migration[5.2]
   def change
     create_table :publishers do |t|

--- a/db/migrate/20201203154002_add_publisher_foreign_key_to_journals.rb
+++ b/db/migrate/20201203154002_add_publisher_foreign_key_to_journals.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddPublisherForeignKeyToJournals < ActiveRecord::Migration[5.2]
   def change
     add_column :journals, :publisher_id, :integer

--- a/db/migrate/20201203162707_rename_publisher_column_on_publications_to_publisher_name.rb
+++ b/db/migrate/20201203162707_rename_publisher_column_on_publications_to_publisher_name.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RenamePublisherColumnOnPublicationsToPublisherName < ActiveRecord::Migration[5.2]
   def change
     rename_column :publications, :publisher, :publisher_name

--- a/db/migrate/20201203175509_add_journal_id_foreign_key_to_publications.rb
+++ b/db/migrate/20201203175509_add_journal_id_foreign_key_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddJournalIdForeignKeyToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :journal_id, :integer

--- a/db/migrate/20210113134957_add_updated_by_owner_at_timestamp_to_authorships.rb
+++ b/db/migrate/20210113134957_add_updated_by_owner_at_timestamp_to_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUpdatedByOwnerAtTimestampToAuthorships < ActiveRecord::Migration[5.2]
   def change
     add_column :authorships, :updated_by_owner_at, :timestamp

--- a/db/migrate/20210113135122_add_exported_to_activity_insight_to_publications.rb
+++ b/db/migrate/20210113135122_add_exported_to_activity_insight_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddExportedToActivityInsightToPublications < ActiveRecord::Migration[5.2]
   def self.up
     add_column :publications, :exported_to_activity_insight, :boolean

--- a/db/migrate/20210121232014_create_statistics_snapshots.rb
+++ b/db/migrate/20210121232014_create_statistics_snapshots.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateStatisticsSnapshots < ActiveRecord::Migration[5.2]
   def change
     create_table :statistics_snapshots do |t|

--- a/db/migrate/20210204222315_add_scholarsphere_open_access_url_to_publications.rb
+++ b/db/migrate/20210204222315_add_scholarsphere_open_access_url_to_publications.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddScholarsphereOpenAccessUrlToPublications < ActiveRecord::Migration[5.2]
   def change
     add_column :publications, :scholarsphere_open_access_url, :text

--- a/db/migrate/20210212185439_rename_contributors_to_contributor_names.rb
+++ b/db/migrate/20210212185439_rename_contributors_to_contributor_names.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RenameContributorsToContributorNames < ActiveRecord::Migration[5.2]
   def change
     rename_table :contributors, :contributor_names

--- a/db/migrate/20210223203349_create_email_errors.rb
+++ b/db/migrate/20210223203349_create_email_errors.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateEmailErrors < ActiveRecord::Migration[5.2]
   def change
     create_table :email_errors do |t|

--- a/db/migrate/20210316165052_create_scholarsphere_file_uploads.rb
+++ b/db/migrate/20210316165052_create_scholarsphere_file_uploads.rb
@@ -1,11 +1,9 @@
-# frozen_string_literal: true
-
 class CreateScholarsphereFileUploads < ActiveRecord::Migration[5.2]
   def change
     create_table :scholarsphere_file_uploads do |t|
       t.references :authorship, foreign_key: true
       t.string :file
       t.timestamps null: false
-    end
+    end    
   end
 end

--- a/db/migrate/20210319193758_create_scholarsphere_work_deposits.rb
+++ b/db/migrate/20210319193758_create_scholarsphere_work_deposits.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateScholarsphereWorkDeposits < ActiveRecord::Migration[5.2]
   def change
     create_table :scholarsphere_work_deposits do |t|

--- a/db/migrate/20210319195338_change_scholarsphere_file_upload_association.rb
+++ b/db/migrate/20210319195338_change_scholarsphere_file_upload_association.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangeScholarsphereFileUploadAssociation < ActiveRecord::Migration[5.2]
   def up
     remove_foreign_key :scholarsphere_file_uploads, :authorships

--- a/db/migrate/20210324160734_add_user_foreign_key_to_contributor_names.rb
+++ b/db/migrate/20210324160734_add_user_foreign_key_to_contributor_names.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddUserForeignKeyToContributorNames < ActiveRecord::Migration[5.2]
   def change
     add_reference :contributor_names, :user, foreign_key: true

--- a/db/migrate/20210330172508_add_required_fields_to_scholarsphere_work_deposits.rb
+++ b/db/migrate/20210330172508_add_required_fields_to_scholarsphere_work_deposits.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddRequiredFieldsToScholarsphereWorkDeposits < ActiveRecord::Migration[5.2]
   def change
     add_column :scholarsphere_work_deposits, :title, :text

--- a/db/migrate/20210331171442_add_embargoed_until_date_to_scholarsphere_work_deposits.rb
+++ b/db/migrate/20210331171442_add_embargoed_until_date_to_scholarsphere_work_deposits.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddEmbargoedUntilDateToScholarsphereWorkDeposits < ActiveRecord::Migration[5.2]
   def change
     add_column :scholarsphere_work_deposits, :embargoed_until, :date

--- a/db/migrate/20210405133643_change_column_names_for_statistic_snapshots.rb
+++ b/db/migrate/20210405133643_change_column_names_for_statistic_snapshots.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangeColumnNamesForStatisticSnapshots < ActiveRecord::Migration[5.2]
   def self.up
     rename_column :statistics_snapshots, :total_publication_count, :total_article_count
@@ -7,7 +5,7 @@ class ChangeColumnNamesForStatisticSnapshots < ActiveRecord::Migration[5.2]
   end
 
   def self.down
-    rename_column :statistics_snapshots, :total_article_count, :total_publication_count
-    rename_column :statistics_snapshots, :open_access_article_count, :open_access_publication_count
+    rename_column :statistics_snapshots, :total_article_count,:total_publication_count
+    rename_column :statistics_snapshots, :open_access_article_count,:open_access_publication_count
   end
 end

--- a/db/migrate/20210416153948_add_doi_to_scholarsphere_work_deposits.rb
+++ b/db/migrate/20210416153948_add_doi_to_scholarsphere_work_deposits.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddDOIToScholarsphereWorkDeposits < ActiveRecord::Migration[5.2]
   def change
     add_column :scholarsphere_work_deposits, :doi, :string

--- a/db/migrate/20210429141455_add_fields_to_scholarsphere_work_deposits.rb
+++ b/db/migrate/20210429141455_add_fields_to_scholarsphere_work_deposits.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddFieldsToScholarsphereWorkDeposits < ActiveRecord::Migration[5.2]
   def change
     add_column :scholarsphere_work_deposits, :subtitle, :text

--- a/db/migrate/20210511183837_add_omniauth_to_users.rb
+++ b/db/migrate/20210511183837_add_omniauth_to_users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddOmniauthToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :provider, :string

--- a/db/migrate/20210618200806_add_publisher_statement_to_scholarsphere_work_deposits.rb
+++ b/db/migrate/20210618200806_add_publisher_statement_to_scholarsphere_work_deposits.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddPublisherStatementToScholarsphereWorkDeposits < ActiveRecord::Migration[5.2]
   def change
     add_column :scholarsphere_work_deposits, :publisher_statement, :text

--- a/db/migrate/20210706131119_remove_scholarsphere_timestamp_from_authorships.rb
+++ b/db/migrate/20210706131119_remove_scholarsphere_timestamp_from_authorships.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RemoveScholarsphereTimestampFromAuthorships < ActiveRecord::Migration[5.2]
   def change
     remove_column :authorships, :scholarsphere_uploaded_at, :datetime

--- a/db/migrate/20210723143828_change_user_phone_number_fields_to_strings.rb
+++ b/db/migrate/20210723143828_change_user_phone_number_fields_to_strings.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ChangeUserPhoneNumberFieldsToStrings < ActiveRecord::Migration[5.2]
   def change
     change_column :users, :ai_office_area_code, :string

--- a/db/migrate/20211006155521_create_importer_error_logs.rb
+++ b/db/migrate/20211006155521_create_importer_error_logs.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateImporterErrorLogs < ActiveRecord::Migration[5.2]
   def change
     create_table :importer_error_logs do |t|

--- a/db/migrate/20211006183554_add_error_message_to_import_error_logs.rb
+++ b/db/migrate/20211006183554_add_error_message_to_import_error_logs.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddErrorMessageToImportErrorLogs < ActiveRecord::Migration[5.2]
   def change
     add_column :importer_error_logs, :error_message, :text, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
 #


### PR DESCRIPTION
This reverts part of ce12441e66572da4ee42f0ebccddd64e88a65be6 to undo the changes made to our database migration files by Rubocop. Although the changes didn't have any significant impact because the schema.rb file was never changed, we want to make sure everything is back to its original pre-Rubocop state.

To prohibit any automated changes to db files in the future, the rubocop.yml file is updated to reflect our current practice of not making changes to certain files.

Apologies to @banukutlu for not catching this earlier. 