### PR TITLE
Update bundler to version 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -597,4 +597,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   1.17.3
+   2.2.29


### PR DESCRIPTION
Closes #204.

Unless I'm missing something, I think we just needed to run a few upgrade commands to update your local environment:

```
gem install bundler
bundle _2.2.29_ update --bundler
```

This updates the version of `bundler` in `Gemfile.lock`.