### PR TITLE
256 update importers

### DIFF
--- a/app/importers/oai_importer.rb
+++ b/app/importers/oai_importer.rb
@@ -24,7 +24,6 @@ class OAIImporter
             p.abstract = rr.description
             p.published_on = rr.date
             p.publisher_name = rr.publisher
-            p.open_access_url = rr.url
             p.publication_type = 'Journal Article'
             p.status = 'Published'
             p.save!
@@ -62,6 +61,12 @@ class OAIImporter
                 a.save!
               end
             end
+
+            oal = OpenAccessLocation.new
+            oal.publication = p
+            oal.url = rr.url
+            oal.source = import_source
+            oal.save!
 
             DuplicatePublicationGroup.group_duplicates_of(p)
 

--- a/app/importers/open_access_button_publication_importer.rb
+++ b/app/importers/open_access_button_publication_importer.rb
@@ -62,6 +62,8 @@ class OpenAccessButtonPublicationImporter
         else
           publication.open_access_locations.create!(source: 'Open Access Button', url: oab_json['url'])
         end
+      else
+        existing_oa_location.try(:destroy)
       end
       publication.open_access_button_last_checked_at = Time.current
       publication.save!

--- a/app/importers/open_access_button_publication_importer.rb
+++ b/app/importers/open_access_button_publication_importer.rb
@@ -54,7 +54,15 @@ class OpenAccessButtonPublicationImporter
       find_url = URI.encode("https://api.openaccessbutton.org/find?id=#{publication.doi_url_path}")
       oab_json = JSON.parse(get_pub(find_url))
 
-      publication.open_access_url = oab_json['url'] if oab_json['url']
+      existing_oa_location = publication.open_access_locations.find_by(source: 'Open Access Button')
+
+      if oab_json['url']
+        if existing_oa_location
+          existing_oa_location.update!(url: oab_json['url'])
+        else
+          publication.open_access_locations.create!(source: 'Open Access Button', url: oab_json['url'])
+        end
+      end
       publication.open_access_button_last_checked_at = Time.current
       publication.save!
 

--- a/app/importers/scholarsphere_importer.rb
+++ b/app/importers/scholarsphere_importer.rb
@@ -7,13 +7,9 @@ class ScholarsphereImporter
       doi_url = k.gsub('doi:', 'https://doi.org/')
       matching_pubs = Publication.where(doi: doi_url)
       matching_pubs.each do |p|
-        if p.scholarsphere_open_access_url.blank?
-          ActiveRecord::Base.transaction do
-            # Update the open access status of the publication by adding the first ScholarSphere
-            # URL that's listed for this publication's DOI.
-            p.scholarsphere_open_access_url = "#{ResearcherMetadata::Application.scholarsphere_base_uri}/resources/#{v.first}"
-            p.save!
-          end
+        v.each do |ss_oa_id|
+          ss_oa_url = "#{ResearcherMetadata::Application.scholarsphere_base_uri}/resources/#{ss_oa_id}"
+          p.open_access_locations.find_or_create_by(source: 'ScholarSphere', url: ss_oa_url)
         end
       end
       pbar.increment unless Rails.env.test?

--- a/app/models/open_access_location.rb
+++ b/app/models/open_access_location.rb
@@ -2,7 +2,14 @@
 
 class OpenAccessLocation < ApplicationRecord
   def self.sources
-    ['User', 'ScholarSphere', 'Open Access Button', 'Unpaywall']
+    [
+      'User',
+      'ScholarSphere',
+      'Open Access Button',
+      'Unpaywall',
+      'Dickinson Law IDEAS Repo',
+      'Penn State Law eLibrary Repo'
+    ]
   end
 
   belongs_to :publication, inverse_of: :open_access_locations

--- a/spec/component/importers/open_access_button_publication_importer_spec.rb
+++ b/spec/component/importers/open_access_button_publication_importer_spec.rb
@@ -276,27 +276,6 @@ describe OpenAccessButtonPublicationImporter do
           importer.import_new
           expect(pub.reload.open_access_button_last_checked_at).to eq now
         end
-
-        context 'when the publication already has an open access location' do
-          let!(:oal) { create :open_access_location,
-                              publication: pub,
-                              url: 'existing_url',
-                              source: 'Open Access Button' }
-
-          it 'does not create any new open access locations' do
-            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
-          end
-
-          it 'updates the existing open access location with the URL to the open access content' do
-            importer.import_new
-            expect(oal.reload.url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_new
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
-        end
       end
     end
 
@@ -352,27 +331,6 @@ describe OpenAccessButtonPublicationImporter do
         context "when the publication has no open access locations" do
           it 'does not create any new open access locations' do
             expect { importer.import_new }.not_to change { OpenAccessLocation.count }
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_new
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
-        end
-
-        context 'when the publication already has an open access location' do
-          let!(:oal) { create :open_access_location,
-                              publication: pub,
-                              url: 'existing_url',
-                              source: 'Open Access Button' }
-
-          it 'does not create any new open access locations' do
-            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
-          end
-
-          it 'does not update the URL for the existing open access location' do
-            importer.import_new
-            expect(oal.reload.url).to eq 'existing_url'
           end
 
           it 'updates Open Access Button check timestamp on the publication' do

--- a/spec/component/importers/open_access_button_publication_importer_spec.rb
+++ b/spec/component/importers/open_access_button_publication_importer_spec.rb
@@ -15,8 +15,8 @@ describe OpenAccessButtonPublicationImporter do
     context 'when an existing publication does not have a DOI' do
       let!(:pub) { create :publication, doi: nil }
 
-      it "does not create any open access locations for the publication" do
-        expect { importer.import_all }.not_to change { OpenAccessLocation.count }
+      it 'does not create any open access locations for the publication' do
+        expect { importer.import_all }.not_to change(OpenAccessLocation, :count)
       end
 
       it "does not update the publication's Open Access Button check timestamp" do
@@ -28,8 +28,8 @@ describe OpenAccessButtonPublicationImporter do
     context 'when an existing publication has a blank DOI' do
       let!(:pub) { create :publication, doi: '' }
 
-      it "does not create any open access locations for the publication" do
-        expect { importer.import_all }.not_to change { OpenAccessLocation.count }
+      it 'does not create any open access locations for the publication' do
+        expect { importer.import_all }.not_to change(OpenAccessLocation, :count)
       end
 
       it "does not update the publication's Open Access Button check timestamp" do
@@ -60,7 +60,7 @@ describe OpenAccessButtonPublicationImporter do
           .and_return(File.read(Rails.root.join('spec', 'fixtures', 'oab1.json')))
       end
 
-      context "when the publication has no open access locations" do
+      context 'when the publication has no open access locations' do
         it 'creates a new open access location for the publication' do
           expect { importer.import_all }.to change { pub.open_access_locations.count }.by 1
         end
@@ -84,7 +84,7 @@ describe OpenAccessButtonPublicationImporter do
                             source: 'Open Access Button' }
 
         it 'does not create any new open access locations' do
-          expect { importer.import_all }.not_to change { OpenAccessLocation.count }
+          expect { importer.import_all }.not_to change(OpenAccessLocation, :count)
         end
 
         it 'updates the existing open access location with the URL to the open access content' do
@@ -108,9 +108,9 @@ describe OpenAccessButtonPublicationImporter do
           .and_return(File.read(Rails.root.join('spec', 'fixtures', 'oab2.json')))
       end
 
-      context "when the publication has no open access locations" do
+      context 'when the publication has no open access locations' do
         it 'does not create any new open access locations' do
-          expect { importer.import_all }.not_to change { OpenAccessLocation.count }
+          expect { importer.import_all }.not_to change(OpenAccessLocation, :count)
         end
 
         it 'updates Open Access Button check timestamp on the publication' do
@@ -125,13 +125,9 @@ describe OpenAccessButtonPublicationImporter do
                             url: 'existing_url',
                             source: 'Open Access Button' }
 
-        it 'does not create any new open access locations' do
-          expect { importer.import_all }.not_to change { OpenAccessLocation.count }
-        end
-
-        it 'does not update the URL for the existing open access location' do
-          importer.import_all
-          expect(oal.reload.url).to eq 'existing_url'
+        it 'removes the existing open access location' do
+          expect { importer.import_all }.to change(OpenAccessLocation, :count).by -1
+          expect { oal.reload }.to raise_error ActiveRecord::RecordNotFound
         end
 
         it 'updates Open Access Button check timestamp on the publication' do
@@ -177,8 +173,8 @@ describe OpenAccessButtonPublicationImporter do
     context 'when an existing publication does not have a DOI' do
       let!(:pub) { create :publication, doi: nil }
 
-      it "does not create any open access locations for the publication" do
-        expect { importer.import_new }.not_to change { OpenAccessLocation.count }
+      it 'does not create any open access locations for the publication' do
+        expect { importer.import_new }.not_to change(OpenAccessLocation, :count)
       end
 
       it "does not update the publication's Open Access Button check timestamp" do
@@ -190,8 +186,8 @@ describe OpenAccessButtonPublicationImporter do
     context 'when an existing publication has a blank DOI' do
       let!(:pub) { create :publication, doi: '' }
 
-      it "does not create any open access locations for the publication" do
-        expect { importer.import_new }.not_to change { OpenAccessLocation.count }
+      it 'does not create any open access locations for the publication' do
+        expect { importer.import_new }.not_to change(OpenAccessLocation, :count)
       end
 
       it "does not update the publication's Open Access Button check timestamp" do
@@ -226,9 +222,9 @@ describe OpenAccessButtonPublicationImporter do
       context 'when the publication has been checked in Open Access Button before' do
         let(:last_check) { Time.new(2021, 1, 1, 0, 0, 0) }
 
-        context "when the publication has no open access locations" do
-          it "does not create any open access locations for the publication" do
-            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
+        context 'when the publication has no open access locations' do
+          it 'does not create any open access locations for the publication' do
+            expect { importer.import_new }.not_to change(OpenAccessLocation, :count)
           end
 
           it 'does not update the Open Access Button check timestamp on the publication' do
@@ -244,7 +240,7 @@ describe OpenAccessButtonPublicationImporter do
                               source: 'Open Access Button' }
 
           it 'does not create any new open access locations' do
-            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
+            expect { importer.import_new }.not_to change(OpenAccessLocation, :count)
           end
 
           it 'does not update the URL for the existing open access location' do
@@ -292,9 +288,9 @@ describe OpenAccessButtonPublicationImporter do
       context 'when the publication has been checked in Open Access Button before' do
         let(:last_check) { Time.new(2021, 1, 1, 0, 0, 0) }
 
-        context "when the publication has no open access locations" do
+        context 'when the publication has no open access locations' do
           it 'does not create any new open access locations' do
-            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
+            expect { importer.import_new }.not_to change(OpenAccessLocation, :count)
           end
 
           it 'does not update the Open Access Button check timestamp on the publication' do
@@ -309,13 +305,9 @@ describe OpenAccessButtonPublicationImporter do
                               url: 'existing_url',
                               source: 'Open Access Button' }
 
-          it 'does not create any new open access locations' do
-            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
-          end
-
-          it 'does not update the URL for the existing open access location' do
-            importer.import_new
-            expect(oal.reload.url).to eq 'existing_url'
+          it 'removes the existing open access location' do
+            expect { importer.import_all }.to change(OpenAccessLocation, :count).by -1
+            expect { oal.reload }.to raise_error ActiveRecord::RecordNotFound
           end
 
           it "does not update the publication's Open Access Button check timestamp" do
@@ -328,9 +320,9 @@ describe OpenAccessButtonPublicationImporter do
       context 'when the publication has never been checked in Open Access Button' do
         let(:last_check) { nil }
 
-        context "when the publication has no open access locations" do
+        context 'when the publication has no open access locations' do
           it 'does not create any new open access locations' do
-            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
+            expect { importer.import_new }.not_to change(OpenAccessLocation, :count)
           end
 
           it 'updates Open Access Button check timestamp on the publication' do

--- a/spec/component/importers/open_access_button_publication_importer_spec.rb
+++ b/spec/component/importers/open_access_button_publication_importer_spec.rb
@@ -15,9 +15,8 @@ describe OpenAccessButtonPublicationImporter do
     context 'when an existing publication does not have a DOI' do
       let!(:pub) { create :publication, doi: nil }
 
-      it "does not update the publication's open access URL" do
-        importer.import_all
-        expect(pub.reload.open_access_url).to be_nil
+      it "does not create any open access locations for the publication" do
+        expect { importer.import_all }.not_to change { OpenAccessLocation.count }
       end
 
       it "does not update the publication's Open Access Button check timestamp" do
@@ -29,9 +28,8 @@ describe OpenAccessButtonPublicationImporter do
     context 'when an existing publication has a blank DOI' do
       let!(:pub) { create :publication, doi: '' }
 
-      it "does not update the publication's open access URL" do
-        importer.import_all
-        expect(pub.reload.open_access_url).to be_nil
+      it "does not create any open access locations for the publication" do
+        expect { importer.import_all }.not_to change { OpenAccessLocation.count }
       end
 
       it "does not update the publication's Open Access Button check timestamp" do
@@ -55,92 +53,43 @@ describe OpenAccessButtonPublicationImporter do
 
     context 'when an existing publication has a DOI that corresponds to an available article listed with Open Access Button' do
       let!(:pub) { create :publication,
-                          doi: 'https://doi.org/10.000/doi1',
-                          open_access_button_last_checked_at: last_check }
+                          doi: 'https://doi.org/10.000/doi1' }
 
       before do
         allow(HTTParty).to receive(:get).with('https://api.openaccessbutton.org/find?id=10.000/doi1')
           .and_return(File.read(Rails.root.join('spec', 'fixtures', 'oab1.json')))
       end
 
-      context 'when the publication was last checked in Open Access Button more than a month ago' do
-        let(:last_check) { now - 32.days }
-
-        context "when the publication's open access URL is nil" do
-          it 'updates the publication with the URL to the open access content' do
-            importer.import_all
-            expect(pub.reload.open_access_url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
+      context "when the publication has no open access locations" do
+        it 'creates a new open access location for the publication' do
+          expect { importer.import_all }.to change { pub.open_access_locations.count }.by 1
         end
 
-        context "when the publication's open access URL is blank" do
-          before { pub.update_attribute(:open_access_url, '') }
-
-          it 'updates the publication with the URL to the open access content' do
-            importer.import_all
-            expect(pub.reload.open_access_url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
-        end
-
-        context 'when the publication already has an open access URL' do
-          before { pub.update_attribute(:open_access_url, 'existing_url') }
-
-          it 'updates the publication with the URL to the open access content' do
-            importer.import_all
-            expect(pub.reload.open_access_url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
-        end
-      end
-
-      context 'when the publication has never been checked in Open Access Button' do
-        let(:last_check) { nil }
-
-        it 'updates the publication with the URL to the open access content' do
+        it 'assigns the metadata from Open Access Button to the new open access location' do
           importer.import_all
-          expect(pub.reload.open_access_url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
+          oal = pub.open_access_locations.find_by(source: 'Open Access Button')
+          expect(oal.url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
         end
 
         it 'updates Open Access Button check timestamp on the publication' do
           importer.import_all
           expect(pub.reload.open_access_button_last_checked_at).to eq now
         end
-
-        context 'when the publication already has an open access URL' do
-          before { pub.update_attribute(:open_access_url, 'existing_url') }
-
-          it 'updates the publication with the URL to the open access content' do
-            importer.import_all
-            expect(pub.reload.open_access_url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
-        end
       end
 
-      context 'when the publication was last checked in Open Access Button less than a month ago' do
-        let(:last_check) { now - 30.days }
+      context 'when the publication already has an open access location from Open Access Button' do
+        let!(:oal) { create :open_access_location,
+                            publication: pub,
+                            url: 'existing_url',
+                            source: 'Open Access Button' }
 
-        it 'updates the publication with the URL to the open access content' do
+        it 'does not create any new open access locations' do
+          expect { importer.import_all }.not_to change { OpenAccessLocation.count }
+        end
+
+        it 'updates the existing open access location with the URL to the open access content' do
           importer.import_all
-          expect(pub.reload.open_access_url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
+          expect(oal.reload.url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
         end
 
         it 'updates Open Access Button check timestamp on the publication' do
@@ -152,108 +101,37 @@ describe OpenAccessButtonPublicationImporter do
 
     context 'when an existing publication has a DOI that does not correspond to an available article listed with Open Access Button' do
       let!(:pub) { create :publication,
-                          doi: 'https://doi.org/10.000/doi1',
-                          open_access_button_last_checked_at: last_check }
+                          doi: 'https://doi.org/10.000/doi1' }
 
       before do
         allow(HTTParty).to receive(:get).with('https://api.openaccessbutton.org/find?id=10.000/doi1')
           .and_return(File.read(Rails.root.join('spec', 'fixtures', 'oab2.json')))
       end
 
-      context 'when the publication was last checked in Open Access Button more than a month ago' do
-        let(:last_check) { now - 32.days }
-
-        context "when the publication's open access URL is nil" do
-          it "does not update the publication's open access URL" do
-            importer.import_all
-            expect(pub.reload.open_access_url).to be_nil
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
+      context "when the publication has no open access locations" do
+        it 'does not create any new open access locations' do
+          expect { importer.import_all }.not_to change { OpenAccessLocation.count }
         end
 
-        context "when the publication's open access URL is blank" do
-          before { pub.update_attribute(:open_access_url, '') }
-
-          it "does not update the publication's open access URL" do
-            importer.import_all
-            expect(pub.reload.open_access_url).to eq ''
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
-        end
-
-        context 'when the publication already has an open access URL' do
-          before { pub.update_attribute(:open_access_url, 'existing_url') }
-
-          it "does not update the publication's open access URL" do
-            importer.import_all
-            expect(pub.reload.open_access_url).to eq 'existing_url'
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
-        end
-      end
-
-      context 'when the publication has never been checked in Open Access Button' do
-        let(:last_check) { nil }
-
-        context "when the publication's open access URL is nil" do
-          it "does not update the publication's open access URL" do
-            importer.import_all
-            expect(pub.reload.open_access_url).to be_nil
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
-        end
-
-        context "when the publication's open access URL is blank" do
-          before { pub.update_attribute(:open_access_url, '') }
-
-          it "does not update the publication's open access URL" do
-            importer.import_all
-            expect(pub.reload.open_access_url).to eq ''
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
-        end
-
-        context 'when the publication already has an open access URL' do
-          before { pub.update_attribute(:open_access_url, 'existing_url') }
-
-          it "does not update the publication's open access URL" do
-            importer.import_all
-            expect(pub.reload.open_access_url).to eq 'existing_url'
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
-        end
-      end
-
-      context 'when the publication was last checked in Open Access Button less than a month ago' do
-        let(:last_check) { now - 30.days }
-
-        it "does not update the publication's open access URL" do
+        it 'updates Open Access Button check timestamp on the publication' do
           importer.import_all
-          expect(pub.reload.open_access_url).to be_nil
+          expect(pub.reload.open_access_button_last_checked_at).to eq now
+        end
+      end
+
+      context 'when the publication already has an open access location' do
+        let!(:oal) { create :open_access_location,
+                            publication: pub,
+                            url: 'existing_url',
+                            source: 'Open Access Button' }
+
+        it 'does not create any new open access locations' do
+          expect { importer.import_all }.not_to change { OpenAccessLocation.count }
+        end
+
+        it 'does not update the URL for the existing open access location' do
+          importer.import_all
+          expect(oal.reload.url).to eq 'existing_url'
         end
 
         it 'updates Open Access Button check timestamp on the publication' do
@@ -299,9 +177,8 @@ describe OpenAccessButtonPublicationImporter do
     context 'when an existing publication does not have a DOI' do
       let!(:pub) { create :publication, doi: nil }
 
-      it "does not update the publication's open access URL" do
-        importer.import_new
-        expect(pub.reload.open_access_url).to be_nil
+      it "does not create any open access locations for the publication" do
+        expect { importer.import_new }.not_to change { OpenAccessLocation.count }
       end
 
       it "does not update the publication's Open Access Button check timestamp" do
@@ -313,9 +190,8 @@ describe OpenAccessButtonPublicationImporter do
     context 'when an existing publication has a blank DOI' do
       let!(:pub) { create :publication, doi: '' }
 
-      it "does not update the publication's open access URL" do
-        importer.import_new
-        expect(pub.reload.open_access_url).to be_nil
+      it "does not create any open access locations for the publication" do
+        expect { importer.import_new }.not_to change { OpenAccessLocation.count }
       end
 
       it "does not update the publication's Open Access Button check timestamp" do
@@ -350,10 +226,9 @@ describe OpenAccessButtonPublicationImporter do
       context 'when the publication has been checked in Open Access Button before' do
         let(:last_check) { Time.new(2021, 1, 1, 0, 0, 0) }
 
-        context "when the publication's open access URL is nil" do
-          it 'does not update the publication with the URL to the open access content' do
-            importer.import_new
-            expect(pub.reload.open_access_url).to eq nil
+        context "when the publication has no open access locations" do
+          it "does not create any open access locations for the publication" do
+            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
           end
 
           it 'does not update the Open Access Button check timestamp on the publication' do
@@ -362,26 +237,19 @@ describe OpenAccessButtonPublicationImporter do
           end
         end
 
-        context "when the publication's open access URL is blank" do
-          before { pub.update_attribute(:open_access_url, '') }
+        context 'when the publication already has an open access location' do
+          let!(:oal) { create :open_access_location,
+                              publication: pub,
+                              url: 'existing_url',
+                              source: 'Open Access Button' }
 
-          it 'does not update the publication with the URL to the open access content' do
-            importer.import_new
-            expect(pub.reload.open_access_url).to eq ''
+          it 'does not create any new open access locations' do
+            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
           end
 
-          it 'does not update the Open Access Button check timestamp on the publication' do
+          it 'does not update the URL for the existing open access location' do
             importer.import_new
-            expect(pub.reload.open_access_button_last_checked_at).to eq Time.new(2021, 1, 1, 0, 0, 0)
-          end
-        end
-
-        context 'when the publication already has an open access URL' do
-          before { pub.update_attribute(:open_access_url, 'existing_url') }
-
-          it "does not update the publication's open access URL" do
-            importer.import_new
-            expect(pub.reload.open_access_url).to eq 'existing_url'
+            expect(oal.reload.url).to eq 'existing_url'
           end
 
           it "does not update the publication's Open Access Button check timestamp" do
@@ -394,9 +262,14 @@ describe OpenAccessButtonPublicationImporter do
       context 'when the publication has never been checked in Open Access Button' do
         let(:last_check) { nil }
 
-        it 'updates the publication with the URL to the open access content' do
+        it 'creates a new open access location for the publication' do
+          expect { importer.import_new }.to change { pub.open_access_locations.count }.by 1
+        end
+
+        it 'assigns the metadata from Open Access Button to the new open access location' do
           importer.import_new
-          expect(pub.reload.open_access_url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
+          oal = pub.open_access_locations.find_by(source: 'Open Access Button')
+          expect(oal.url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
         end
 
         it 'updates Open Access Button check timestamp on the publication' do
@@ -404,32 +277,25 @@ describe OpenAccessButtonPublicationImporter do
           expect(pub.reload.open_access_button_last_checked_at).to eq now
         end
 
-        context 'when the publication already has an open access URL' do
-          before { pub.update_attribute(:open_access_url, 'existing_url') }
+        context 'when the publication already has an open access location' do
+          let!(:oal) { create :open_access_location,
+                              publication: pub,
+                              url: 'existing_url',
+                              source: 'Open Access Button' }
 
-          it 'updates the publication with the URL to the open access content' do
+          it 'does not create any new open access locations' do
+            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
+          end
+
+          it 'updates the existing open access location with the URL to the open access content' do
             importer.import_new
-            expect(pub.reload.open_access_url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
+            expect(oal.reload.url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
           end
 
           it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_all
+            importer.import_new
             expect(pub.reload.open_access_button_last_checked_at).to eq now
           end
-        end
-      end
-
-      context 'when the publication has been checked in Open Access Button before' do
-        let(:last_check) { Time.new(2021, 1, 1, 0, 0, 0) }
-
-        it 'does not update the publication with the URL to the open access content' do
-          importer.import_new
-          expect(pub.reload.open_access_url).to eq nil
-        end
-
-        it 'does not update the Open Access Button check timestamp on the publication' do
-          importer.import_new
-          expect(pub.reload.open_access_button_last_checked_at).to eq Time.new(2021, 1, 1, 0, 0, 0)
         end
       end
     end
@@ -447,10 +313,9 @@ describe OpenAccessButtonPublicationImporter do
       context 'when the publication has been checked in Open Access Button before' do
         let(:last_check) { Time.new(2021, 1, 1, 0, 0, 0) }
 
-        context "when the publication's open access URL is nil" do
-          it "does not update the publication's open access URL" do
-            importer.import_new
-            expect(pub.reload.open_access_url).to be_nil
+        context "when the publication has no open access locations" do
+          it 'does not create any new open access locations' do
+            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
           end
 
           it 'does not update the Open Access Button check timestamp on the publication' do
@@ -459,26 +324,19 @@ describe OpenAccessButtonPublicationImporter do
           end
         end
 
-        context "when the publication's open access URL is blank" do
-          before { pub.update_attribute(:open_access_url, '') }
+        context 'when the publication already has an open access location' do
+          let!(:oal) { create :open_access_location,
+                              publication: pub,
+                              url: 'existing_url',
+                              source: 'Open Access Button' }
 
-          it "does not update the publication's open access URL" do
-            importer.import_new
-            expect(pub.reload.open_access_url).to eq ''
+          it 'does not create any new open access locations' do
+            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
           end
 
-          it 'does not update the Open Access Button check timestamp on the publication' do
+          it 'does not update the URL for the existing open access location' do
             importer.import_new
-            expect(pub.reload.open_access_button_last_checked_at).to eq Time.new(2021, 1, 1, 0, 0, 0)
-          end
-        end
-
-        context 'when the publication already has an open access URL' do
-          before { pub.update_attribute(:open_access_url, 'existing_url') }
-
-          it "does not update the publication's open access URL" do
-            importer.import_new
-            expect(pub.reload.open_access_url).to eq 'existing_url'
+            expect(oal.reload.url).to eq 'existing_url'
           end
 
           it "does not update the publication's Open Access Button check timestamp" do
@@ -491,10 +349,9 @@ describe OpenAccessButtonPublicationImporter do
       context 'when the publication has never been checked in Open Access Button' do
         let(:last_check) { nil }
 
-        context "when the publication's open access URL is nil" do
-          it "does not update the publication's open access URL" do
-            importer.import_new
-            expect(pub.reload.open_access_url).to be_nil
+        context "when the publication has no open access locations" do
+          it 'does not create any new open access locations' do
+            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
           end
 
           it 'updates Open Access Button check timestamp on the publication' do
@@ -503,46 +360,25 @@ describe OpenAccessButtonPublicationImporter do
           end
         end
 
-        context "when the publication's open access URL is blank" do
-          before { pub.update_attribute(:open_access_url, '') }
+        context 'when the publication already has an open access location' do
+          let!(:oal) { create :open_access_location,
+                              publication: pub,
+                              url: 'existing_url',
+                              source: 'Open Access Button' }
 
-          it "does not update the publication's open access URL" do
+          it 'does not create any new open access locations' do
+            expect { importer.import_new }.not_to change { OpenAccessLocation.count }
+          end
+
+          it 'does not update the URL for the existing open access location' do
             importer.import_new
-            expect(pub.reload.open_access_url).to eq ''
+            expect(oal.reload.url).to eq 'existing_url'
           end
 
           it 'updates Open Access Button check timestamp on the publication' do
             importer.import_new
             expect(pub.reload.open_access_button_last_checked_at).to eq now
           end
-        end
-
-        context 'when the publication already has an open access URL' do
-          before { pub.update_attribute(:open_access_url, 'existing_url') }
-
-          it "does not update the publication's open access URL" do
-            importer.import_new
-            expect(pub.reload.open_access_url).to eq 'existing_url'
-          end
-
-          it 'updates Open Access Button check timestamp on the publication' do
-            importer.import_all
-            expect(pub.reload.open_access_button_last_checked_at).to eq now
-          end
-        end
-      end
-
-      context 'when the publication has been checked in Open Access Button before' do
-        let(:last_check) { Time.new(2021, 1, 1, 0, 0, 0) }
-
-        it "does not update the publication's open access URL" do
-          importer.import_new
-          expect(pub.reload.open_access_url).to be_nil
-        end
-
-        it 'does not update the Open Access Button check timestamp on the publication' do
-          importer.import_new
-          expect(pub.reload.open_access_button_last_checked_at).to eq Time.new(2021, 1, 1, 0, 0, 0)
         end
       end
     end

--- a/spec/component/importers/psu_dickinson_publication_importer_spec.rb
+++ b/spec/component/importers/psu_dickinson_publication_importer_spec.rb
@@ -74,6 +74,10 @@ describe PSUDickinsonPublicationImporter do
       expect { importer.call }.to change(ContributorName, :count).by 2
     end
 
+    it "creates new open access locations for records that are importable and that don't already exist" do
+      expect { importer.call }.to change(OpenAccessLocation, :count).by 1
+    end
+
     it 'is idempotent in terms of creating publication imports' do
       importer.call
       expect { importer.call }.not_to change(PublicationImport, :count)
@@ -94,6 +98,11 @@ describe PSUDickinsonPublicationImporter do
       expect { importer.call }.not_to change(ContributorName, :count)
     end
 
+    it 'is idempotent in terms of creating open access locations' do
+      importer.call
+      expect { importer.call }.not_to change(OpenAccessLocation, :count)
+    end
+
     it 'saves the correct metadata' do
       importer.call
       import = PublicationImport.find_by(source: 'Dickinson Law IDEAS Repo',
@@ -104,7 +113,6 @@ describe PSUDickinsonPublicationImporter do
       expect(pub.abstract).to eq 'a description of the article'
       expect(pub.published_on).to eq Date.new(2020, 1, 1)
       expect(pub.publisher_name).to eq 'The Publisher'
-      expect(pub.open_access_url).to eq 'https://example.com/article'
       expect(pub.publication_type).to eq 'Journal Article'
       expect(pub.status).to eq 'Published'
       expect(pub.journal_title).to eq 'The Source'
@@ -129,6 +137,9 @@ describe PSUDickinsonPublicationImporter do
       auth3 = pub.authorships.find_by(user: u3)
       expect(auth3.author_number).to eq 2
       expect(auth3.confirmed).to eq false
+
+      oal = pub.open_access_locations.find_by(source: 'Dickinson Law IDEAS Repo')
+      expect(oal.url).to eq 'https://example.com/article'
     end
 
     it 'groups duplicates of new publication records' do

--- a/spec/component/importers/psu_law_school_publication_importer_spec.rb
+++ b/spec/component/importers/psu_law_school_publication_importer_spec.rb
@@ -74,6 +74,10 @@ describe PSULawSchoolPublicationImporter do
       expect { importer.call }.to change(ContributorName, :count).by 2
     end
 
+    it "creates new open access locations for records that are importable and that don't already exist" do
+      expect { importer.call }.to change(OpenAccessLocation, :count).by 1
+    end
+
     it 'is idempotent in terms of creating publication imports' do
       importer.call
       expect { importer.call }.not_to change(PublicationImport, :count)
@@ -94,6 +98,11 @@ describe PSULawSchoolPublicationImporter do
       expect { importer.call }.not_to change(ContributorName, :count)
     end
 
+    it 'is idempotent in terms of creating open access locations' do
+      importer.call
+      expect { importer.call }.not_to change(OpenAccessLocation, :count)
+    end
+
     it 'saves the correct metadata' do
       importer.call
       import = PublicationImport.find_by(source: 'Penn State Law eLibrary Repo',
@@ -104,7 +113,6 @@ describe PSULawSchoolPublicationImporter do
       expect(pub.abstract).to eq 'a description of the article'
       expect(pub.published_on).to eq Date.new(2020, 1, 1)
       expect(pub.publisher_name).to eq 'The Publisher'
-      expect(pub.open_access_url).to eq 'https://example.com/article'
       expect(pub.publication_type).to eq 'Journal Article'
       expect(pub.status).to eq 'Published'
       expect(pub.journal_title).to eq 'The Source'
@@ -129,6 +137,9 @@ describe PSULawSchoolPublicationImporter do
       auth3 = pub.authorships.find_by(user: u3)
       expect(auth3.author_number).to eq 2
       expect(auth3.confirmed).to eq false
+
+      oal = pub.open_access_locations.find_by(source: 'Penn State Law eLibrary Repo')
+      expect(oal.url).to eq 'https://example.com/article'
     end
 
     it 'groups duplicates of new publication records' do

--- a/spec/component/importers/scholarsphere_importer_spec.rb
+++ b/spec/component/importers/scholarsphere_importer_spec.rb
@@ -23,23 +23,24 @@ describe ScholarsphereImporter do
 
     context 'when a publication exists in the database that matches an incoming DOI' do
       let!(:pub) { create :publication,
-                          doi: 'https://doi.org/10.1016/j.scitotenv.2021.145145',
-                          scholarsphere_open_access_url: url }
-      let(:url) { '' }
+                          doi: 'https://doi.org/10.1109/5.771073' }
 
-      context 'when the publication already has a ScholarSphere open access URL' do
-        let(:url) { 'a_url' }
+      context 'when the publication already has an open access location that matches a URL from ScholarSphere' do
+        let!(:oal) { create :open_access_location,
+                            source: 'ScholarSphere',
+                            publication: pub,
+                            url: 'https://scholarsphere.test/resources/67b85129-8431-494a-8a3e-a8d07cd350bc'}
 
-        it 'does not update the URL' do
-          importer.call
-          expect(pub.reload.scholarsphere_open_access_url).to eq 'a_url'
-        end
-      end
-
-      context 'when the publication does not already have a ScholarSphere open access URL' do
-        it "updates the publication with the first ScholarSphere URL listed for the publication's DOI" do
-          importer.call
-          expect(pub.reload.scholarsphere_open_access_url).to eq 'https://scholarsphere.test/resources/cd1542ae-087d-4f32-b920-5a7faaab63ac'
+        it 'only creates new open access locations for new URLs from ScholarSphere' do
+          expect { importer.call }.to change(OpenAccessLocation, :count).by 2
+          expect(pub.open_access_locations.find_by(
+                   source: 'ScholarSphere',
+                   url: 'https://scholarsphere.test/resources/0b591fea-7bef-4e06-9554-6417bf2c040e'
+                 )).not_to be_nil
+          expect(pub.open_access_locations.find_by(
+                   source: 'ScholarSphere',
+                   url: 'https://scholarsphere.test/resources/21dd75c1-65c8-49ba-959a-9443ab27dc16'
+                 )).not_to be_nil
         end
       end
     end

--- a/spec/component/importers/scholarsphere_importer_spec.rb
+++ b/spec/component/importers/scholarsphere_importer_spec.rb
@@ -21,23 +21,38 @@ describe ScholarsphereImporter do
       allow(ResearcherMetadata::Application).to receive(:scholarsphere_base_uri).and_return 'https://scholarsphere.test'
     end
 
-    context 'when a publication exists in the database that matches an incoming DOI' do
-      let!(:pub) { create :publication,
-                          doi: 'https://doi.org/10.1109/5.771073' }
+    context 'when a publications exist in the database that match an incoming DOI' do
+      let!(:pub1) { create :publication,
+                           doi: 'https://doi.org/10.1109/5.771073' }
+      let!(:pub2) { create :publication,
+                           doi: 'https://doi.org/10.1109/5.771073' }
 
-      context 'when the publication already has an open access location that matches a URL from ScholarSphere' do
+      context 'when one of the publications already has an open access location that matches a URL from ScholarSphere' do
         let!(:oal) { create :open_access_location,
                             source: 'ScholarSphere',
-                            publication: pub,
+                            publication: pub1,
                             url: 'https://scholarsphere.test/resources/67b85129-8431-494a-8a3e-a8d07cd350bc'}
 
-        it 'only creates new open access locations for new URLs from ScholarSphere' do
-          expect { importer.call }.to change(OpenAccessLocation, :count).by 2
-          expect(pub.open_access_locations.find_by(
+        it 'creates new open access locations only for new URLs from ScholarSphere for each publication' do
+          expect { importer.call }.to change(OpenAccessLocation, :count).by 5
+          expect(pub1.open_access_locations.find_by(
                    source: 'ScholarSphere',
                    url: 'https://scholarsphere.test/resources/0b591fea-7bef-4e06-9554-6417bf2c040e'
                  )).not_to be_nil
-          expect(pub.open_access_locations.find_by(
+          expect(pub1.open_access_locations.find_by(
+                   source: 'ScholarSphere',
+                   url: 'https://scholarsphere.test/resources/21dd75c1-65c8-49ba-959a-9443ab27dc16'
+                 )).not_to be_nil
+
+          expect(pub2.open_access_locations.find_by(
+                   source: 'ScholarSphere',
+                   url: 'https://scholarsphere.test/resources/0b591fea-7bef-4e06-9554-6417bf2c040e'
+                 )).not_to be_nil
+          expect(pub2.open_access_locations.find_by(
+                   source: 'ScholarSphere',
+                   url: 'https://scholarsphere.test/resources/67b85129-8431-494a-8a3e-a8d07cd350bc'
+                 )).not_to be_nil
+          expect(pub2.open_access_locations.find_by(
                    source: 'ScholarSphere',
                    url: 'https://scholarsphere.test/resources/21dd75c1-65c8-49ba-959a-9443ab27dc16'
                  )).not_to be_nil

--- a/spec/component/importers/scholarsphere_importer_spec.rb
+++ b/spec/component/importers/scholarsphere_importer_spec.rb
@@ -25,8 +25,6 @@ describe ScholarsphereImporter do
       let!(:pub) { create :publication,
                           doi: 'https://doi.org/10.1016/j.scitotenv.2021.145145',
                           scholarsphere_open_access_url: url }
-      let!(:auth1) { create :authorship, publication: pub }
-      let!(:auth2) { create :authorship, publication: pub }
       let(:url) { '' }
 
       context 'when the publication already has a ScholarSphere open access URL' do

--- a/spec/component/models/open_access_location_spec.rb
+++ b/spec/component/models/open_access_location_spec.rb
@@ -43,7 +43,14 @@ describe OpenAccessLocation, type: :model do
 
   describe '.sources' do
     it 'returns an array of the possible sources of open access location data' do
-      expect(described_class.sources).to eq ['User', 'ScholarSphere', 'Open Access Button', 'Unpaywall']
+      expect(described_class.sources).to eq [
+        'User',
+        'ScholarSphere',
+        'Open Access Button',
+        'Unpaywall',
+        'Dickinson Law IDEAS Repo',
+        'Penn State Law eLibrary Repo'
+      ]
     end
   end
 end


### PR DESCRIPTION
I think this is ready to go, but we may not want to merge it until we have some of the other Unpaywall changes finished and merged. If this goes out to production by itself, it will stop new data from being imported into the places where it's currently being used in production. That's not a huge deal, but it would be better to avoid.