### PR TITLE
Improve the admin UI label for open access location records

### DIFF
--- a/app/models/open_access_location.rb
+++ b/app/models/open_access_location.rb
@@ -10,6 +10,10 @@ class OpenAccessLocation < ApplicationRecord
   validates :publication, :source, :url, presence: true
   validates :source, inclusion: { in: sources }
 
+  def name
+    "#{url} (#{source})"
+  end
+
   rails_admin do
     show do
       include_all_fields

--- a/spec/component/models/open_access_location_spec.rb
+++ b/spec/component/models/open_access_location_spec.rb
@@ -46,4 +46,12 @@ describe OpenAccessLocation, type: :model do
       expect(described_class.sources).to eq ['User', 'ScholarSphere', 'Open Access Button', 'Unpaywall']
     end
   end
+
+  describe '#name' do
+    let(:oal) { described_class.new(url: 'https://example.com/article', source: 'User') }
+
+    it "returns a string that includes the location's URL and source" do
+      expect(oal.name).to eq 'https://example.com/article (User)'
+    end
+  end
 end

--- a/spec/integration/admin/open_access_locations/show_spec.rb
+++ b/spec/integration/admin/open_access_locations/show_spec.rb
@@ -27,7 +27,7 @@ describe 'Admin open access location detail page', type: :feature do
       before { visit rails_admin.show_path(model_name: :open_access_location, id: oal.id) }
 
       it 'shows the location detail heading' do
-        expect(page).to have_content "Details for Open access location 'OpenAccessLocation ##{oal.id}'"
+        expect(page).to have_content "Details for Open access location 'https://nature.com/articles/testpub123 (Unpaywall)'"
       end
 
       it "shows the location's host type" do

--- a/spec/integration/admin/publications/show_spec.rb
+++ b/spec/integration/admin/publications/show_spec.rb
@@ -73,10 +73,14 @@ describe 'Admin publication detail page', type: :feature do
                       publication: pub }
 
   let!(:oal1) { create :open_access_location,
-                       publication: pub }
+                       publication: pub,
+                       source: 'User',
+                       url: 'https://example.com/oal1' }
 
   let!(:oal2) { create :open_access_location,
-                       publication: pub }
+                       publication: pub,
+                       source: 'ScholarSphere',
+                       url: 'https://scholarsphere.psu.edu/oal2' }
 
   let!(:journal) { create :journal,
                           title: 'Test Journal Record' }
@@ -177,9 +181,9 @@ describe 'Admin publication detail page', type: :feature do
       end
 
       it "shows the publication's open access locations" do
-        expect(page).to have_link "OpenAccessLocation ##{oal1.id}",
+        expect(page).to have_link 'https://example.com/oal1 (User)',
                                   href: rails_admin.show_path(model_name: :open_access_location, id: oal1.id)
-        expect(page).to have_link "OpenAccessLocation ##{oal2.id}",
+        expect(page).to have_link 'https://scholarsphere.psu.edu/oal2 (ScholarSphere)',
                                   href: rails_admin.show_path(model_name: :open_access_location, id: oal2.id)
       end
 


### PR DESCRIPTION
Minor change requested by @anaelizabethenriquez:

The admin UI now displays the labels/links for `OpenAccessLocation` records in the form of "https://example.com/the-article-url (Source)"


@anaelizabethenriquez, will you still need to see the open access URLs in the publication list also? And a related question - do you need to be able to filter and/or sort the publication list based on the open access URLs and their sources?