### PR TITLE
Allow admins to perform limited management of open access metadata

### DIFF
--- a/app/models/open_access_location.rb
+++ b/app/models/open_access_location.rb
@@ -14,14 +14,36 @@ class OpenAccessLocation < ApplicationRecord
     show do
       include_all_fields
 
+      field(:oa_date) { label 'OA date' }
       field(:url) do
+        label 'URL'
         pretty_value { %{<a href="#{value}" target="_blank">#{value}</a>}.html_safe if value }
       end
       field(:landing_page_url) do
+        label 'Landing page URL'
         pretty_value { %{<a href="#{value}" target="_blank">#{value}</a>}.html_safe if value }
       end
       field(:pdf_url) do
+        label 'PDF URL'
         pretty_value { %{<a href="#{value}" target="_blank">#{value}</a>}.html_safe if value }
+      end
+    end
+
+    create do
+      field(:url) { label 'URL' }
+      field(:source, :enum) do
+        enum do
+          [value || 'User']
+        end
+      end
+    end
+
+    edit do
+      field(:url) { label 'URL' }
+      field(:source, :enum) do
+        enum do
+          [value || 'User']
+        end
       end
     end
   end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -92,6 +92,7 @@ class Publication < ApplicationRecord
   accepts_nested_attributes_for :authorships, allow_destroy: true
   accepts_nested_attributes_for :contributor_names, allow_destroy: true
   accepts_nested_attributes_for :taggings, allow_destroy: true
+  accepts_nested_attributes_for :open_access_locations, allow_destroy: true
 
   def self.find_by_wos_pub(pub)
     by_doi = pub.doi ? where(doi: pub.doi) : Publication.none
@@ -445,6 +446,7 @@ class Publication < ApplicationRecord
       field(:doi) { label 'DOI' }
       field(:user_submitted_open_access_url) { label 'User-submitted open access URL' }
       field(:scholarsphere_open_access_url) { label 'Scholarsphere Open Access URL' }
+      field(:open_access_locations)
       field(:issn) { label 'ISSN' }
       field(:abstract)
       field(:authors_et_al) { label 'Et al authors?' }

--- a/app/rails_admin_actions/delete.rb
+++ b/app/rails_admin_actions/delete.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module RailsAdmin
+  module Config
+    module Actions
+      class Delete < RailsAdmin::Config::Actions::Base
+        RailsAdmin::Config::Actions.register(self)
+
+        register_instance_option :member do
+          true
+        end
+
+        register_instance_option :route_fragment do
+          'delete'
+        end
+
+        register_instance_option :http_methods do
+          [:get, :delete]
+        end
+
+        register_instance_option :authorization_key do
+          :destroy
+        end
+
+        register_instance_option :controller do
+          proc do
+            if request.get? # DELETE
+
+              respond_to do |format|
+                format.html { render @action.template_name }
+                format.js   { render @action.template_name, layout: false }
+              end
+
+            elsif request.delete? # DESTROY
+
+              @auditing_adapter&.delete_object(@object, @abstract_model, _current_user)
+              if @object.destroy
+                flash[:success] = t('admin.flash.successful', name: @model_config.label, action: t('admin.actions.delete.done'))
+                if @object.is_a? OpenAccessLocation
+                  redirect_to show_path(model_name: :publication, id: @object.publication.id)
+                else
+                  redirect_to index_path
+                end
+              else
+                handle_save_error :delete
+              end
+
+            end
+          end
+        end
+
+        register_instance_option :link_icon do
+          'icon-remove'
+        end
+      end
+    end
+  end
+end

--- a/app/rails_admin_actions/edit.rb
+++ b/app/rails_admin_actions/edit.rb
@@ -35,7 +35,13 @@ module RailsAdmin
               if @object.save
                 @auditing_adapter&.update_object(@object, @abstract_model, _current_user, changes)
                 respond_to do |format|
-                  format.html { redirect_to_on_success }
+                  format.html do
+                    if @object.is_a? OpenAccessLocation
+                      redirect_to show_path(id: @object.id)
+                    else
+                      redirect_to_on_success
+                    end
+                  end
                   format.js { render json: { id: @object.id.to_s, label: @model_config.with(object: @object).object_label } }
                 end
               else

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -70,7 +70,8 @@ RailsAdmin.config do |config|
             :User,
             :APIToken,
             :ExternalPublicationWaiver,
-            :InternalPublicationWaiver]
+            :InternalPublicationWaiver,
+            :OpenAccessLocation]
     end
     export
     bulk_delete do
@@ -86,10 +87,15 @@ RailsAdmin.config do |config|
             :Performance,
             :APIToken,
             :ExternalPublicationWaiver,
-            :InternalPublicationWaiver]
+            :InternalPublicationWaiver,
+            :OpenAccessLocation]
     end
     delete do
-      only [:Publication, :User, :APIToken, :ExternalPublicationWaiver]
+      only [:Publication,
+            :User,
+            :APIToken,
+            :ExternalPublicationWaiver,
+            :OpenAccessLocation]
     end
     index_publications_by_organization do
       only [:Publication]

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -167,6 +167,7 @@ describe Publication, type: :model do
   it { is_expected.to accept_nested_attributes_for(:authorships).allow_destroy(true) }
   it { is_expected.to accept_nested_attributes_for(:contributor_names).allow_destroy(true) }
   it { is_expected.to accept_nested_attributes_for(:taggings).allow_destroy(true) }
+  it { is_expected.to accept_nested_attributes_for(:open_access_locations).allow_destroy(true) }
 
   describe 'deleting a publication with authorships' do
     let(:p) { create :publication }

--- a/spec/integration/admin/api_tokens/delete_spec.rb
+++ b/spec/integration/admin/api_tokens/delete_spec.rb
@@ -27,6 +27,10 @@ describe 'Deleting an API Token', type: :feature do
       it 'deletes the API token' do
         expect { token.reload }.to raise_error ActiveRecord::RecordNotFound
       end
+
+      it 'redirects to the API token list' do
+        expect(page).to have_current_path rails_admin.index_path(model_name: :api_token), ignore_query: true
+      end
     end
   end
 

--- a/spec/integration/admin/open_access_locations/create_spec.rb
+++ b/spec/integration/admin/open_access_locations/create_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+require 'integration/admin/shared_examples_for_admin_page'
+
+describe 'Creating an open access location', type: :feature do
+  context 'when the current user is an admin' do
+    before do
+      authenticate_admin_user
+      visit rails_admin.new_path(model_name: :open_access_location)
+    end
+
+    describe 'visiting the form to create a new open access location' do
+      # The rails_admin `create` action is enabled for open access locations so
+      # that admin users can add a location to a publication via nested attributes
+      # on the publication record. The action that renders the form for creating a
+      # new open access location directly is not intended to actually be used (there
+      # are no links to it in the admin UI). In fact, the 'new' form isn't even
+      # configured to show all of the required fields when rendered outside of the
+      # context of a publication. So we can't actually submit the form that we're
+      # testing here. The purpose of this test is just to verify that the `create`
+      # action is enabled and that the form is configured with the correct fields for
+      # the nested context.
+      it_behaves_like 'a page with the admin layout'
+      it 'shows the correct content' do
+        expect(page).to have_content 'New Open access location'
+      end
+
+      it 'shows the correct fields' do
+        expect(page).to have_field 'URL'
+        expect(page).to have_field 'Source'
+      end
+
+      it 'shows the correct options for the Source field', js: true do
+        find('.dropdown-toggle').click
+        within '#ui-id-1' do
+          expect(page).to have_content 'User'
+        end
+      end
+    end
+  end
+
+  context 'when the current user is not an admin' do
+    before { authenticate_user }
+
+    it 'redirects back to the home page with an error message' do
+      visit rails_admin.new_path(model_name: :open_access_location)
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content I18n.t('admin.authorization.not_authorized')
+    end
+  end
+end

--- a/spec/integration/admin/open_access_locations/delete_spec.rb
+++ b/spec/integration/admin/open_access_locations/delete_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+require 'integration/admin/shared_examples_for_admin_page'
+
+describe 'deleting an open access location via the admin interface', type: :feature do
+  let!(:oal) { create :open_access_location,
+                      source: 'Open Access Button',
+                      url: 'https://example.com/test',
+                      publication: pub }
+  let(:pub) { create :publication }
+
+  context 'when the current user is an admin' do
+    before do
+      authenticate_admin_user
+      visit rails_admin.delete_path(model_name: :open_access_location, id: oal.id)
+    end
+
+    describe 'visiting the form to delete the open access location' do
+      it_behaves_like 'a page with the admin layout'
+
+      it 'show the correct content' do
+        expect(page).to have_content 'Are you sure you want to delete this open access location'
+      end
+    end
+
+    describe 'submitting the form to delete the open access location' do
+      before { click_button "Yes, I'm sure" }
+
+      it 'destroys the open access location record' do
+        expect { oal.reload }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it "redirects to the detail page for the deleted location's publication" do
+        expect(page).to have_current_path rails_admin.show_path(model_name: :publication, id: pub.id), ignore_query: true
+      end
+    end
+  end
+
+  context 'when the current user is not an admin' do
+    before { authenticate_user }
+
+    it 'redirects back to the home page with an error message' do
+      visit rails_admin.delete_path(model_name: :open_access_location, id: oal.id)
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content I18n.t('admin.authorization.not_authorized')
+    end
+  end
+end

--- a/spec/integration/admin/open_access_locations/update_spec.rb
+++ b/spec/integration/admin/open_access_locations/update_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+require 'integration/admin/shared_examples_for_admin_page'
+
+describe 'updating an open access location via the admin interface', type: :feature do
+  let!(:oal) { create :open_access_location,
+                      source: 'Open Access Button',
+                      url: 'https://example.com/test' }
+
+  context 'when the current user is an admin' do
+    before do
+      authenticate_admin_user
+      visit rails_admin.edit_path(model_name: :open_access_location, id: oal.id)
+    end
+
+    describe 'viewing the edit page' do
+      it 'shows the correct fields' do
+        expect(page).to have_field 'URL'
+        expect(page).to have_field 'Source'
+      end
+
+      it 'shows the correct options for the Source field', js: true do
+        find('.dropdown-toggle').click
+        within '#ui-id-1' do
+          expect(page).to have_content 'Open Access Button'
+          expect(page).not_to have_content 'User'
+        end
+      end
+    end
+
+    describe 'submitting the form with new data to update the open access location record' do
+      before do
+        fill_in 'URL', with: 'https://example.com/new'
+        click_on 'Save'
+      end
+
+      it "updates the open access location record's URL" do
+        expect(oal.reload.url).to eq 'https://example.com/new'
+      end
+
+      it "does not update the open access location record's source" do
+        expect(oal.reload.source).to eq 'Open Access Button'
+      end
+
+      it 'redirects back to the detail view of the open access location' do
+        expect(page).to have_current_path rails_admin.show_path(model_name: :open_access_location, id: oal.id), ignore_query: true
+      end
+    end
+  end
+
+  context 'when the current user is not an admin' do
+    before { authenticate_user }
+
+    it 'redirects back to the home page with an error message' do
+      visit rails_admin.edit_path(model_name: :open_access_location, id: oal.id)
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content I18n.t('admin.authorization.not_authorized')
+    end
+  end
+end

--- a/spec/integration/admin/publications/update_spec.rb
+++ b/spec/integration/admin/publications/update_spec.rb
@@ -18,6 +18,10 @@ describe 'updating a publication via the admin interface', type: :feature do
       it 'does not allow the total Scopus citations to be set' do
         expect(page).not_to have_field 'Total scopus citations'
       end
+
+      it 'shows a nested form for adding open access locations' do
+        expect(page).to have_content 'Add a new Open access location'
+      end
     end
 
     describe 'submitting the form with new data to update a publication record' do

--- a/spec/integration/admin/users/update_spec.rb
+++ b/spec/integration/admin/users/update_spec.rb
@@ -105,6 +105,10 @@ describe 'updating a user via the admin interface', type: :feature do
       it 'sets the timestamp on the user record to indicate that it was manually updated' do
         expect(user.reload.updated_by_user_at).not_to be_blank
       end
+
+      it 'redirects back to the user list' do
+        expect(page).to have_current_path rails_admin.index_path(model_name: :user), ignore_query: true
+      end
     end
   end
 


### PR DESCRIPTION
This allows admin users to:

1. add new open access locations to a publication by submitting only a URL and source value of 'User'
2. edit existing open access locations for a publication and change only the URL attribute of the location
3. delete open access locations from a publication
