### PR TITLE
OpenAccessUrlsMigrationService for migrating open access urls from old data model to new data model.

### DIFF
--- a/app/services/open_access_urls_migration_service.rb
+++ b/app/services/open_access_urls_migration_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class OpenAccessUrlsMigrationService
+  def self.call
+    Publication.all.each do |pub|
+      if pub.open_access_url
+        OpenAccessLocation.find_or_create_by(source: 'Open Access Button',
+                                             url: pub.open_access_url,
+                                             publication_id: pub.id)
+      elsif pub.scholarsphere_open_access_url
+        OpenAccessLocation.find_or_create_by(source: 'ScholarSphere',
+                                             url: pub.scholarsphere_open_access_url,
+                                             publication_id: pub.id)
+      elsif pub.user_submitted_open_access_url
+        OpenAccessLocation.find_or_create_by(source: 'User',
+                                             url: pub.user_submitted_open_access_url,
+                                             publication_id: pub.id)
+      end
+    end
+  end
+end

--- a/app/services/open_access_urls_migration_service.rb
+++ b/app/services/open_access_urls_migration_service.rb
@@ -2,7 +2,7 @@
 
 class OpenAccessUrlsMigrationService
   def self.call
-    Publication.all.each do |pub|
+    Publication.find_each do |pub|
       if pub.open_access_url
         OpenAccessLocation.find_or_create_by(source: 'Open Access Button',
                                              url: pub.open_access_url,

--- a/app/services/open_access_urls_migration_service.rb
+++ b/app/services/open_access_urls_migration_service.rb
@@ -4,17 +4,17 @@ class OpenAccessUrlsMigrationService
   def self.call
     Publication.find_each do |pub|
       if pub.open_access_url
-        OpenAccessLocation.find_or_create_by(source: 'Open Access Button',
+        OpenAccessLocation.find_or_create_by(source: Source::OPEN_ACCESS_BUTTON,
                                              url: pub.open_access_url,
                                              publication_id: pub.id)
       end
       if pub.scholarsphere_open_access_url
-        OpenAccessLocation.find_or_create_by(source: 'ScholarSphere',
+        OpenAccessLocation.find_or_create_by(source: Source::SCHOLARSPHERE,
                                              url: pub.scholarsphere_open_access_url,
                                              publication_id: pub.id)
       end
       if pub.user_submitted_open_access_url
-        OpenAccessLocation.find_or_create_by(source: 'User',
+        OpenAccessLocation.find_or_create_by(source: Source::USER,
                                              url: pub.user_submitted_open_access_url,
                                              publication_id: pub.id)
       end

--- a/app/services/open_access_urls_migration_service.rb
+++ b/app/services/open_access_urls_migration_service.rb
@@ -7,11 +7,13 @@ class OpenAccessUrlsMigrationService
         OpenAccessLocation.find_or_create_by(source: 'Open Access Button',
                                              url: pub.open_access_url,
                                              publication_id: pub.id)
-      elsif pub.scholarsphere_open_access_url
+      end
+      if pub.scholarsphere_open_access_url
         OpenAccessLocation.find_or_create_by(source: 'ScholarSphere',
                                              url: pub.scholarsphere_open_access_url,
                                              publication_id: pub.id)
-      elsif pub.user_submitted_open_access_url
+      end
+      if pub.user_submitted_open_access_url
         OpenAccessLocation.find_or_create_by(source: 'User',
                                              url: pub.user_submitted_open_access_url,
                                              publication_id: pub.id)

--- a/lib/tasks/migrate_open_access_urls.rake
+++ b/lib/tasks/migrate_open_access_urls.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+desc 'Migrate open access URLs from old data model to new data model'
+task migrate_open_access_urls: :environment do
+  OpenAccessUrlsMigrationService.call
+end

--- a/spec/component/services/open_access_urls_migration_service_spec.rb
+++ b/spec/component/services/open_access_urls_migration_service_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+describe OpenAccessUrlsMigrationService do
+  before do
+    5.times { create :publication, open_access_url: 'example.com' }
+    5.times { create :publication, scholarsphere_open_access_url: 'scholarsphere.edu' }
+    5.times { create :publication, user_submitted_open_access_url: 'user_example.com' }
+    5.times do
+      create :publication, user_submitted_open_access_url: 'user_example.com', open_access_url: 'example.com'
+    end
+    5.times do
+      create :publication, scholarsphere_open_access_url: 'scholarsphere.edu', open_access_url: 'example.com'
+    end
+    5.times do
+      create :publication, user_submitted_open_access_url: 'user_example.com',
+             scholarsphere_open_access_url: 'scholarsphere.edu'
+    end
+    5.times do
+      create :publication, user_submitted_open_access_url: 'user_example.com',
+             scholarsphere_open_access_url: 'scholarsphere.edu',
+             open_access_url: 'example.com'
+    end
+  end
+
+  describe '#call' do
+    it 'creates OpenAccessLocation records from Publication open access url data' do
+      expect{ described_class.call }.to change{ OpenAccessLocation.count }.by 60
+    end
+
+    it 'creates OpenAccessLocation records with proper attributes' do
+      oa_url_pub = create :publication, open_access_url: 'oa_url.com'
+      ss_oa_url_pub = create :publication, scholarsphere_open_access_url: 'ss_oa_url.edu'
+      user_oa_url_pub = create :publication, user_submitted_open_access_url: 'user_oa_url.com'
+
+      described_class.call
+      expect(OpenAccessLocation.find_by(url: oa_url_pub.open_access_url).source).to eq 'Open Access Button'
+      expect(OpenAccessLocation.find_by(url: oa_url_pub.open_access_url).publication_id).to eq oa_url_pub.id
+      expect(OpenAccessLocation.find_by(url: ss_oa_url_pub.scholarsphere_open_access_url).source).to eq 'ScholarSphere'
+      expect(OpenAccessLocation.find_by(url: ss_oa_url_pub.scholarsphere_open_access_url).publication_id).to eq ss_oa_url_pub.id
+      expect(OpenAccessLocation.find_by(url: user_oa_url_pub.user_submitted_open_access_url).source).to eq 'User'
+      expect(OpenAccessLocation.find_by(url: user_oa_url_pub.user_submitted_open_access_url).publication_id).to eq user_oa_url_pub.id
+    end
+
+    it 'is idempotent' do
+      described_class.call
+      expect{ described_class.call }.not_to change{ OpenAccessLocation.count }
+    end
+  end
+end

--- a/spec/component/services/open_access_urls_migration_service_spec.rb
+++ b/spec/component/services/open_access_urls_migration_service_spec.rb
@@ -27,11 +27,11 @@ describe OpenAccessUrlsMigrationService do
       user_oa_url_pub = create :publication, user_submitted_open_access_url: 'user_oa_url.com'
 
       described_class.call
-      expect(OpenAccessLocation.find_by(url: oa_url_pub.open_access_url).source).to eq 'Open Access Button'
+      expect(OpenAccessLocation.find_by(url: oa_url_pub.open_access_url).source).to eq Source::OPEN_ACCESS_BUTTON
       expect(OpenAccessLocation.find_by(url: oa_url_pub.open_access_url).publication_id).to eq oa_url_pub.id
-      expect(OpenAccessLocation.find_by(url: ss_oa_url_pub.scholarsphere_open_access_url).source).to eq 'ScholarSphere'
+      expect(OpenAccessLocation.find_by(url: ss_oa_url_pub.scholarsphere_open_access_url).source).to eq Source::SCHOLARSPHERE
       expect(OpenAccessLocation.find_by(url: ss_oa_url_pub.scholarsphere_open_access_url).publication_id).to eq ss_oa_url_pub.id
-      expect(OpenAccessLocation.find_by(url: user_oa_url_pub.user_submitted_open_access_url).source).to eq 'User'
+      expect(OpenAccessLocation.find_by(url: user_oa_url_pub.user_submitted_open_access_url).source).to eq Source::USER
       expect(OpenAccessLocation.find_by(url: user_oa_url_pub.user_submitted_open_access_url).publication_id).to eq user_oa_url_pub.id
     end
 

--- a/spec/component/services/open_access_urls_migration_service_spec.rb
+++ b/spec/component/services/open_access_urls_migration_service_spec.rb
@@ -4,29 +4,21 @@ require 'component/component_spec_helper'
 
 describe OpenAccessUrlsMigrationService do
   before do
-    5.times { create :publication, open_access_url: 'example.com' }
-    5.times { create :publication, scholarsphere_open_access_url: 'scholarsphere.edu' }
-    5.times { create :publication, user_submitted_open_access_url: 'user_example.com' }
-    5.times do
-      create :publication, user_submitted_open_access_url: 'user_example.com', open_access_url: 'example.com'
-    end
-    5.times do
-      create :publication, scholarsphere_open_access_url: 'scholarsphere.edu', open_access_url: 'example.com'
-    end
-    5.times do
-      create :publication, user_submitted_open_access_url: 'user_example.com',
-             scholarsphere_open_access_url: 'scholarsphere.edu'
-    end
-    5.times do
-      create :publication, user_submitted_open_access_url: 'user_example.com',
-             scholarsphere_open_access_url: 'scholarsphere.edu',
-             open_access_url: 'example.com'
-    end
+    create_list :publication, 5, open_access_url: 'example.com'
+    create_list :publication, 5, scholarsphere_open_access_url: 'scholarsphere.edu'
+    create_list :publication, 5, user_submitted_open_access_url: 'user_example.com'
+    create_list :publication, 5, user_submitted_open_access_url: 'user_example.com', open_access_url: 'example.com'
+    create_list :publication, 5, scholarsphere_open_access_url: 'scholarsphere.edu', open_access_url: 'example.com'
+    create_list :publication, 5, user_submitted_open_access_url: 'user_example.com',
+                                 scholarsphere_open_access_url: 'scholarsphere.edu'
+    create_list :publication, 5, user_submitted_open_access_url: 'user_example.com',
+                                 scholarsphere_open_access_url: 'scholarsphere.edu',
+                                 open_access_url: 'example.com'
   end
 
   describe '#call' do
     it 'creates OpenAccessLocation records from Publication open access url data' do
-      expect{ described_class.call }.to change{ OpenAccessLocation.count }.by 60
+      expect { described_class.call }.to change(OpenAccessLocation, :count).by 60
     end
 
     it 'creates OpenAccessLocation records with proper attributes' do
@@ -45,7 +37,7 @@ describe OpenAccessUrlsMigrationService do
 
     it 'is idempotent' do
       described_class.call
-      expect{ described_class.call }.not_to change{ OpenAccessLocation.count }
+      expect { described_class.call }.not_to change(OpenAccessLocation, :count)
     end
   end
 end


### PR DESCRIPTION
closes #259 

**Do not merge** until Ryan is done with his refactoring, so I can implement his `source` methods.