### PR TITLE
WIP: OpenAccessLocation uses a value object for sources

### DIFF
--- a/app/importers/oai_importer.rb
+++ b/app/importers/oai_importer.rb
@@ -65,7 +65,7 @@ class OAIImporter
             oal = OpenAccessLocation.new
             oal.publication = p
             oal.url = rr.url
-            oal.source = import_source
+            oal.source = location_source # TODO return to import_source once import sources are refactored
             oal.save!
 
             DuplicatePublicationGroup.group_duplicates_of(p)
@@ -90,6 +90,14 @@ class OAIImporter
     end
 
     def import_source
+      raise NotImplementedError.new('This method should be defined in a subclass')
+    end
+
+    # TODO this is a temporary method so we can refactor the sources used in
+    # OpenAccessLocation and PublicationImport separately. Once botha are refactored
+    # to use the Source object, then we should remove this method and only
+    # use #import_source
+    def location_source
       raise NotImplementedError.new('This method should be defined in a subclass')
     end
 

--- a/app/importers/open_access_button_publication_importer.rb
+++ b/app/importers/open_access_button_publication_importer.rb
@@ -54,13 +54,13 @@ class OpenAccessButtonPublicationImporter
       find_url = URI.encode("https://api.openaccessbutton.org/find?id=#{publication.doi_url_path}")
       oab_json = JSON.parse(get_pub(find_url))
 
-      existing_oa_location = publication.open_access_locations.find_by(source: 'Open Access Button')
+      existing_oa_location = publication.open_access_locations.find_by(source: Source::OPEN_ACCESS_BUTTON)
 
       if oab_json['url']
         if existing_oa_location
           existing_oa_location.update!(url: oab_json['url'])
         else
-          publication.open_access_locations.create!(source: 'Open Access Button', url: oab_json['url'])
+          publication.open_access_locations.create!(source: Source::OPEN_ACCESS_BUTTON, url: oab_json['url'])
         end
       else
         existing_oa_location.try(:destroy)

--- a/app/importers/psu_dickinson_publication_importer.rb
+++ b/app/importers/psu_dickinson_publication_importer.rb
@@ -11,6 +11,14 @@ class PSUDickinsonPublicationImporter < OAIImporter
       'Dickinson Law IDEAS Repo'
     end
 
+    # TODO this is a temporary method so we can refactor the sources used in
+    # OpenAccessLocation and PublicationImport separately. Once botha are refactored
+    # to use the Source object, then we should remove this method and only
+    # use #import_source
+    def location_source
+      Source::DICKINSON_IDEAS
+    end
+
     def repo_url
       'https://ideas.dickinsonlaw.psu.edu/do/oai'
     end

--- a/app/importers/psu_law_school_publication_importer.rb
+++ b/app/importers/psu_law_school_publication_importer.rb
@@ -11,6 +11,14 @@ class PSULawSchoolPublicationImporter < OAIImporter
       'Penn State Law eLibrary Repo'
     end
 
+    # TODO this is a temporary method so we can refactor the sources used in
+    # OpenAccessLocation and PublicationImport separately. Once botha are refactored
+    # to use the Source object, then we should remove this method and only
+    # use #import_source
+    def location_source
+      Source::PSU_LAW_ELIBRARY
+    end
+
     def repo_url
       'https://elibrary.law.psu.edu/do/oai'
     end

--- a/app/importers/scholarsphere_importer.rb
+++ b/app/importers/scholarsphere_importer.rb
@@ -9,7 +9,7 @@ class ScholarsphereImporter
       matching_pubs.each do |p|
         v.each do |ss_oa_id|
           ss_oa_url = "#{ResearcherMetadata::Application.scholarsphere_base_uri}/resources/#{ss_oa_id}"
-          p.open_access_locations.find_or_create_by(source: 'ScholarSphere', url: ss_oa_url)
+          p.open_access_locations.find_or_create_by(source: Source::SCHOLARSPHERE, url: ss_oa_url)
         end
       rescue StandardError => e
         log_error(e, {

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -6,4 +6,10 @@ class ApplicationRecord < ActiveRecord::Base
   def mark_as_updated_by_user
     # It's up to subclasses to implement this if applicable.
   end
+
+  def self.to_enum_hash(arr)
+    arr
+      .map { |sym| [sym.to_sym, sym.to_s] }
+      .to_h
+  end
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Source
+  USER = 'user'
+  SCHOLARSPHERE = 'scholarsphere'
+  OPEN_ACCESS_BUTTON = 'open_access_button'
+  UNPAYWALL = 'unpaywall'
+  DICKINSON_IDEAS = 'dickinson_ideas'
+  PSU_LAW_ELIBRARY = 'psu_law_elibrary'
+
+  def initialize(source)
+    @source = source
+  end
+
+  def ==(other)
+    to_s == other.to_s
+  end
+  alias :eql? :==
+
+  def display
+    I18n.t(
+      @source,
+      scope: [:source],
+      default: @source.to_s.humanize.titleize
+    )
+  end
+
+  def to_s
+    @source
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,3 +94,10 @@ en:
   omniauth:
     login_error: "There was an error while attempting to log in to your account. Please contact RMD support for assistance."
     user_not_found: "You do not have a user account in the Researcher Metadata Database. Please contact RMD support if you believe that this is incorrect."
+  source:
+    user: 'User'
+    scholarsphere: 'ScholarSphere'
+    open_access_button: 'Open Access Button'
+    unpaywall: 'Unpaywall'
+    dickinson_ideas: 'Dickinson Law IDEAS Repo'
+    psu_law_elibrary: 'Penn State Law eLibrary Repo'

--- a/spec/component/importers/open_access_button_publication_importer_spec.rb
+++ b/spec/component/importers/open_access_button_publication_importer_spec.rb
@@ -67,7 +67,7 @@ describe OpenAccessButtonPublicationImporter do
 
         it 'assigns the metadata from Open Access Button to the new open access location' do
           importer.import_all
-          oal = pub.open_access_locations.find_by(source: 'Open Access Button')
+          oal = pub.open_access_locations.find_by(source: Source::OPEN_ACCESS_BUTTON)
           expect(oal.url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
         end
 
@@ -81,7 +81,7 @@ describe OpenAccessButtonPublicationImporter do
         let!(:oal) { create :open_access_location,
                             publication: pub,
                             url: 'existing_url',
-                            source: 'Open Access Button' }
+                            source: Source::OPEN_ACCESS_BUTTON}
 
         it 'does not create any new open access locations' do
           expect { importer.import_all }.not_to change(OpenAccessLocation, :count)
@@ -123,7 +123,7 @@ describe OpenAccessButtonPublicationImporter do
         let!(:oal) { create :open_access_location,
                             publication: pub,
                             url: 'existing_url',
-                            source: 'Open Access Button' }
+                            source: Source::OPEN_ACCESS_BUTTON}
 
         it 'removes the existing open access location' do
           expect { importer.import_all }.to change(OpenAccessLocation, :count).by -1
@@ -237,7 +237,7 @@ describe OpenAccessButtonPublicationImporter do
           let!(:oal) { create :open_access_location,
                               publication: pub,
                               url: 'existing_url',
-                              source: 'Open Access Button' }
+                              source: Source::OPEN_ACCESS_BUTTON}
 
           it 'does not create any new open access locations' do
             expect { importer.import_new }.not_to change(OpenAccessLocation, :count)
@@ -264,7 +264,7 @@ describe OpenAccessButtonPublicationImporter do
 
         it 'assigns the metadata from Open Access Button to the new open access location' do
           importer.import_new
-          oal = pub.open_access_locations.find_by(source: 'Open Access Button')
+          oal = pub.open_access_locations.find_by(source: Source::OPEN_ACCESS_BUTTON)
           expect(oal.url).to eq 'http://openaccessexample.org/publications/pub1.pdf'
         end
 
@@ -303,7 +303,7 @@ describe OpenAccessButtonPublicationImporter do
           let!(:oal) { create :open_access_location,
                               publication: pub,
                               url: 'existing_url',
-                              source: 'Open Access Button' }
+                              source: Source::OPEN_ACCESS_BUTTON}
 
           it 'removes the existing open access location' do
             expect { importer.import_all }.to change(OpenAccessLocation, :count).by -1

--- a/spec/component/importers/psu_dickinson_publication_importer_spec.rb
+++ b/spec/component/importers/psu_dickinson_publication_importer_spec.rb
@@ -138,7 +138,7 @@ describe PSUDickinsonPublicationImporter do
       expect(auth3.author_number).to eq 2
       expect(auth3.confirmed).to eq false
 
-      oal = pub.open_access_locations.find_by(source: 'Dickinson Law IDEAS Repo')
+      oal = pub.open_access_locations.find_by(source: Source::DICKINSON_IDEAS)
       expect(oal.url).to eq 'https://example.com/article'
     end
 

--- a/spec/component/importers/psu_law_school_publication_importer_spec.rb
+++ b/spec/component/importers/psu_law_school_publication_importer_spec.rb
@@ -138,7 +138,7 @@ describe PSULawSchoolPublicationImporter do
       expect(auth3.author_number).to eq 2
       expect(auth3.confirmed).to eq false
 
-      oal = pub.open_access_locations.find_by(source: 'Penn State Law eLibrary Repo')
+      oal = pub.open_access_locations.find_by(source: Source::PSU_LAW_ELIBRARY)
       expect(oal.url).to eq 'https://example.com/article'
     end
 

--- a/spec/component/importers/scholarsphere_importer_spec.rb
+++ b/spec/component/importers/scholarsphere_importer_spec.rb
@@ -29,31 +29,31 @@ describe ScholarsphereImporter do
 
       context 'when one of the publications already has an open access location that matches a URL from ScholarSphere' do
         let!(:oal) { create :open_access_location,
-                            source: 'ScholarSphere',
+                            source: Source::SCHOLARSPHERE,
                             publication: pub1,
                             url: 'https://scholarsphere.test/resources/67b85129-8431-494a-8a3e-a8d07cd350bc'}
 
         it 'creates new open access locations only for new URLs from ScholarSphere for each publication' do
           expect { importer.call }.to change(OpenAccessLocation, :count).by 5
           expect(pub1.open_access_locations.find_by(
-                   source: 'ScholarSphere',
+                   source: Source::SCHOLARSPHERE,
                    url: 'https://scholarsphere.test/resources/0b591fea-7bef-4e06-9554-6417bf2c040e'
                  )).not_to be_nil
           expect(pub1.open_access_locations.find_by(
-                   source: 'ScholarSphere',
+                   source: Source::SCHOLARSPHERE,
                    url: 'https://scholarsphere.test/resources/21dd75c1-65c8-49ba-959a-9443ab27dc16'
                  )).not_to be_nil
 
           expect(pub2.open_access_locations.find_by(
-                   source: 'ScholarSphere',
+                   source: Source::SCHOLARSPHERE,
                    url: 'https://scholarsphere.test/resources/0b591fea-7bef-4e06-9554-6417bf2c040e'
                  )).not_to be_nil
           expect(pub2.open_access_locations.find_by(
-                   source: 'ScholarSphere',
+                   source: Source::SCHOLARSPHERE,
                    url: 'https://scholarsphere.test/resources/67b85129-8431-494a-8a3e-a8d07cd350bc'
                  )).not_to be_nil
           expect(pub2.open_access_locations.find_by(
-                   source: 'ScholarSphere',
+                   source: Source::SCHOLARSPHERE,
                    url: 'https://scholarsphere.test/resources/21dd75c1-65c8-49ba-959a-9443ab27dc16'
                  )).not_to be_nil
         end

--- a/spec/component/models/open_access_location_spec.rb
+++ b/spec/component/models/open_access_location_spec.rb
@@ -27,35 +27,44 @@ describe 'the open_access_locations table', type: :model do
 end
 
 describe OpenAccessLocation, type: :model do
+  subject(:oal) { described_class.new }
+
   it_behaves_like 'an application record'
 
   describe 'associations' do
     it { is_expected.to belong_to(:publication).inverse_of(:open_access_locations) }
   end
 
-  describe 'validations' do
-    it { is_expected.to validate_presence_of(:publication) }
-    it { is_expected.to validate_presence_of(:source) }
-    it { is_expected.to validate_presence_of(:url) }
-
-    it { is_expected.to validate_inclusion_of(:source).in_array(described_class.sources) }
+  specify do
+    expect(oal).to define_enum_for(:source)
+      .backed_by_column_of_type(:string)
+      .with_values(
+        user: 'user',
+        scholarsphere: 'scholarsphere',
+        open_access_button: 'open_access_button',
+        unpaywall: 'unpaywall',
+        dickinson_ideas: 'dickinson_ideas',
+        psu_law_elibrary: 'psu_law_elibrary'
+      )
+      .with_prefix(:source)
   end
 
-  describe '.sources' do
-    it 'returns an array of the possible sources of open access location data' do
-      expect(described_class.sources).to eq [
-        'User',
-        'ScholarSphere',
-        'Open Access Button',
-        'Unpaywall',
-        'Dickinson Law IDEAS Repo',
-        'Penn State Law eLibrary Repo'
-      ]
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:publication) }
+    it { is_expected.not_to allow_value(nil).for(:source) }
+    it { is_expected.to validate_presence_of(:url) }
+  end
+
+  describe '#source' do
+    it 'is a Source value object' do
+      oal = described_class.new(source: Source::USER)
+      expect(oal.source).to be_a(Source)
+      expect(oal.source.to_s).to eq Source::USER
     end
   end
 
   describe '#name' do
-    let(:oal) { described_class.new(url: 'https://example.com/article', source: 'User') }
+    let(:oal) { described_class.new(url: 'https://example.com/article', source: Source::USER) }
 
     it "returns a string that includes the location's URL and source" do
       expect(oal.name).to eq 'https://example.com/article (User)'

--- a/spec/component/models/source_spec.rb
+++ b/spec/component/models/source_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+describe Source do
+  specify { expect(described_class::USER).to eq 'user' }
+  specify { expect(described_class::SCHOLARSPHERE).to eq 'scholarsphere' }
+  specify { expect(described_class::OPEN_ACCESS_BUTTON).to eq 'open_access_button' }
+  specify { expect(described_class::UNPAYWALL).to eq 'unpaywall' }
+  specify { expect(described_class::DICKINSON_IDEAS).to eq 'dickinson_ideas' }
+  specify { expect(described_class::PSU_LAW_ELIBRARY).to eq 'psu_law_elibrary' }
+
+  describe '#eql?' do
+    it 'compares to strings' do
+      expect(described_class.new('user')).to eq 'user'
+    end
+  end
+
+  describe '#display' do
+    {
+      described_class::USER => 'User',
+      described_class::SCHOLARSPHERE => 'ScholarSphere',
+      described_class::OPEN_ACCESS_BUTTON => 'Open Access Button',
+      described_class::UNPAYWALL => 'Unpaywall',
+      described_class::DICKINSON_IDEAS => 'Dickinson Law IDEAS Repo',
+      described_class::PSU_LAW_ELIBRARY => 'Penn State Law eLibrary Repo'
+    }.each do |source, expected_display_value|
+      it "translates #{source.inspect} into #{expected_display_value.inspect}" do
+        src = described_class.new(source)
+        expect(src.display).to eq expected_display_value
+      end
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns the string value of the source' do
+      src = described_class.new(described_class::OPEN_ACCESS_BUTTON)
+      expect(src.to_s).to eq described_class::OPEN_ACCESS_BUTTON
+    end
+  end
+end

--- a/spec/factories/open_access_location.rb
+++ b/spec/factories/open_access_location.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :open_access_location do
     publication
-    source { 'User' }
+    source { Source::USER }
     url { 'test_url' }
   end
 end

--- a/spec/integration/admin/open_access_locations/delete_spec.rb
+++ b/spec/integration/admin/open_access_locations/delete_spec.rb
@@ -5,7 +5,7 @@ require 'integration/admin/shared_examples_for_admin_page'
 
 describe 'deleting an open access location via the admin interface', type: :feature do
   let!(:oal) { create :open_access_location,
-                      source: 'Open Access Button',
+                      source: Source::OPEN_ACCESS_BUTTON,
                       url: 'https://example.com/test',
                       publication: pub }
   let(:pub) { create :publication }

--- a/spec/integration/admin/open_access_locations/show_spec.rb
+++ b/spec/integration/admin/open_access_locations/show_spec.rb
@@ -9,7 +9,7 @@ describe 'Admin open access location detail page', type: :feature do
                       host_type: 'publisher',
                       license: 'cc-by-nc',
                       oa_date: Date.new(2020, 5, 3),
-                      source: 'Unpaywall',
+                      source: Source::UNPAYWALL,
                       source_updated_at: Time.new(2021, 10, 7, 18, 7, 0, '+00:00'),
                       url: 'https://nature.com/articles/testpub123',
                       landing_page_url: 'https://nature.com/articles/testpub123/info',

--- a/spec/integration/admin/open_access_locations/update_spec.rb
+++ b/spec/integration/admin/open_access_locations/update_spec.rb
@@ -5,7 +5,7 @@ require 'integration/admin/shared_examples_for_admin_page'
 
 describe 'updating an open access location via the admin interface', type: :feature do
   let!(:oal) { create :open_access_location,
-                      source: 'Open Access Button',
+                      source: Source::OPEN_ACCESS_BUTTON,
                       url: 'https://example.com/test' }
 
   context 'when the current user is an admin' do
@@ -23,7 +23,7 @@ describe 'updating an open access location via the admin interface', type: :feat
       it 'shows the correct options for the Source field', js: true do
         find('.dropdown-toggle').click
         within '#ui-id-1' do
-          expect(page).to have_content 'Open Access Button'
+          expect(page).to have_content Source.new(Source::OPEN_ACCESS_BUTTON).display
           expect(page).not_to have_content 'User'
         end
       end
@@ -40,7 +40,7 @@ describe 'updating an open access location via the admin interface', type: :feat
       end
 
       it "does not update the open access location record's source" do
-        expect(oal.reload.source).to eq 'Open Access Button'
+        expect(oal.reload.source).to eq Source::OPEN_ACCESS_BUTTON
       end
 
       it 'redirects back to the detail view of the open access location' do

--- a/spec/integration/admin/publications/show_spec.rb
+++ b/spec/integration/admin/publications/show_spec.rb
@@ -74,12 +74,12 @@ describe 'Admin publication detail page', type: :feature do
 
   let!(:oal1) { create :open_access_location,
                        publication: pub,
-                       source: 'User',
+                       source: Source::USER,
                        url: 'https://example.com/oal1' }
 
   let!(:oal2) { create :open_access_location,
                        publication: pub,
-                       source: 'ScholarSphere',
+                       source: Source::SCHOLARSPHERE,
                        url: 'https://scholarsphere.psu.edu/oal2' }
 
   let!(:journal) { create :journal,


### PR DESCRIPTION
Changes the use of magic strings used in the `OpenAccessLocation` model, and replaces them with a value object, `Source` which...

- defines the string that is ultimately stored in the database as a constant
- Also defines the human-friendly presentational values, stored en en.yml

The OpenAccessLocation model uses these constants as an `enum`, which
- validates that the attribute is present
- validates that the attribute is in the given list
- creates some scopes for finding/filtering, e.g. `OpenAccessLocation.source_scholarsphere.find_all`
- creates handy predicate methods, e.g. `my_oal_instance.source_scholarsphere?`

By default, Rails enums are stored as integers in the database, which I do not like because it makes your data totally opaque. A small modification allows them to be stored as string values in the db, which I like a lot better. That's what the helper method `to_enum_hash` does.

Closes #294 

The same Source value object and a similar enum can be used over on `PublicationImport` for #295, and you'll see some comments in this PR where I had to tweak a couple private methods to allow this bifurcation. Those will go away once #295 is done.

I see that CI has exploded on the integration specs. I'll update those later, but for now, please take a look at what I have so far