### PR TITLE
Do not render progress bars in test mode, or non-interactive terminals

### DIFF
--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -10,10 +10,10 @@ class ActivityInsightImporter
   attr_reader :errors
 
   def call
-    pbar = ProgressBar.create(title: 'Importing Activity Insight Data', total: ai_users.count) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing Activity Insight Data', total: ai_users.count)
 
     ai_users.each do |aiu|
-      pbar.increment unless Rails.env.test?
+      pbar.increment
       u = User.find_by(webaccess_id: aiu.webaccess_id) || User.new
       details = ai_user_detail(aiu.raw_webaccess_id)
 
@@ -198,7 +198,7 @@ class ActivityInsightImporter
       end
     end
 
-    pbar.finish unless Rails.env.test?
+    pbar.finish
   end
 
   private
@@ -225,7 +225,7 @@ class ActivityInsightImporter
     end
 
     def ai_users
-      return @users if @users.present?
+      return @users unless @users.nil?
 
       users_xml = Nokogiri::XML(ai_users_xml)
       @users = users_xml.css('Users User').map { |u| ActivityInsightListUser.new(u) }

--- a/app/importers/csv_importer.rb
+++ b/app/importers/csv_importer.rb
@@ -17,12 +17,12 @@ class CSVImporter
   end
 
   def call
-    pbar = ProgressBar.create(title: 'Importing CSV', total: line_count) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing CSV', total: line_count)
     chunk_number = 0
     SmarterCSV.process(filename, chunk_size: batch_size, headers_in_file: true, file_encoding: encoding) do |chunk|
       objects = []
       chunk.each_with_index.map do |row, index|
-        pbar.increment unless Rails.env.test?
+        pbar.increment
         row_number = (chunk_number * batch_size) + index + 1
         begin
           object = row_to_object(row)
@@ -37,7 +37,7 @@ class CSVImporter
       bulk_import(objects)
       chunk_number += 1
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
     raise ParseError, fatal_errors if fatal_errors_encountered?
   end
 
@@ -62,7 +62,10 @@ class CSVImporter
     end
 
     def line_count
-      `wc -l #{filename}`.to_i - 1
+      [
+        `wc -l #{filename}`.to_i - 1,
+        0
+      ].max
     end
 
     def encoding

--- a/app/importers/ldap_importer.rb
+++ b/app/importers/ldap_importer.rb
@@ -2,7 +2,7 @@
 
 class LDAPImporter
   def call
-    pbar = ProgressBar.create(title: 'Importing user data from LDAP', total: User.count) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing user data from LDAP', total: User.count)
     ldap.open do
       User.find_each do |u|
         filter = Net::LDAP::Filter.eq('uid', u.webaccess_id)
@@ -13,7 +13,7 @@ class LDAPImporter
           u.save!
         end
 
-        pbar.increment unless Rails.env.test?
+        pbar.increment
       rescue StandardError => e
         log_error(e, {
                     user_id: u&.id,
@@ -21,7 +21,7 @@ class LDAPImporter
                   })
       end
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
   rescue StandardError => e
     log_error(e, {})
   end

--- a/app/importers/nsf_grant_importer.rb
+++ b/app/importers/nsf_grant_importer.rb
@@ -12,7 +12,7 @@ class NSFGrantImporter
 
     import_dirs.each do |d|
       import_files = Dir.children(dirname.join(d)).select { |f| File.extname(f) == '.xml' }
-      pbar = ProgressBar.create(title: "Importing NSF Grant Data for #{d}", total: import_files.count) unless Rails.env.test?
+      pbar = ProgressBarTTY.create(title: "Importing NSF Grant Data for #{d}", total: import_files.count)
       import_files.each do |file|
         nsf_grant = NSFGrant.new(File.open(dirname.join(d).join(file)) { |f| Nokogiri::XML(f) })
 
@@ -37,9 +37,9 @@ class NSFGrantImporter
             end
           end
         end
-        pbar.increment unless Rails.env.test?
+        pbar.increment
       end
-      pbar.finish unless Rails.env.test?
+      pbar.finish
     end
   end
 

--- a/app/importers/oai_importer.rb
+++ b/app/importers/oai_importer.rb
@@ -4,10 +4,10 @@ class OAIImporter
   def call
     puts "Loading publication records from #{repo_url} ..." unless Rails.env.test?
     load_records
-    pbar = ProgressBar.create(title: 'Importing publications', total: repo_records.count) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing publications', total: repo_records.count)
 
     repo_records.each do |rr|
-      pbar.increment unless Rails.env.test?
+      pbar.increment
 
       if rr.any_user_matches?
         ActiveRecord::Base.transaction do
@@ -77,7 +77,7 @@ class OAIImporter
         end
       end
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
     nil
   end
 

--- a/app/importers/open_access_button_publication_importer.rb
+++ b/app/importers/open_access_button_publication_importer.rb
@@ -2,8 +2,8 @@
 
 class OpenAccessButtonPublicationImporter
   def import_all
-    pbar = ProgressBar.create(title: 'Importing publication data from Open Access Button',
-                              total: all_pubs.count)
+    pbar = ProgressBarTTY.create(title: 'Importing publication data from Open Access Button',
+                                 total: all_pubs.count)
 
     all_pubs.find_each do |p|
       query_open_access_button_for(p)
@@ -13,8 +13,8 @@ class OpenAccessButtonPublicationImporter
   end
 
   def import_new
-    pbar = ProgressBar.create(title: 'Importing publication data from Open Access Button',
-                              total: new_pubs.count)
+    pbar = ProgressBarTTY.create(title: 'Importing publication data from Open Access Button',
+                                 total: new_pubs.count)
 
     new_pubs.find_each do |p|
       query_open_access_button_for(p)

--- a/app/importers/psu_identity_importer.rb
+++ b/app/importers/psu_identity_importer.rb
@@ -19,7 +19,7 @@ class PsuIdentityImporter
   private
 
     def progress_bar
-      @progress_bar ||= ProgressBar.create(title: 'Importing data from Penn State Identity API', total: User.count)
+      @progress_bar ||= ProgressBarTTY.create(title: 'Importing data from Penn State Identity API', total: User.count)
     end
 
     def log_error(error, user = nil)

--- a/app/importers/pure_journals_importer.rb
+++ b/app/importers/pure_journals_importer.rb
@@ -2,7 +2,7 @@
 
 class PureJournalsImporter < PureImporter
   def call
-    pbar = ProgressBar.create(title: 'Importing Pure journals', total: total_pages) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing Pure journals', total: total_pages)
 
     1.upto(total_pages) do |i|
       offset = (i - 1) * page_size
@@ -20,11 +20,11 @@ class PureJournalsImporter < PureImporter
                     item: item
                   })
       end
-      pbar.increment unless Rails.env.test?
+      pbar.increment
     rescue StandardError => e
       log_error(e, {})
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
   rescue StandardError => e
     log_error(e, {})
   end

--- a/app/importers/pure_organizations_importer.rb
+++ b/app/importers/pure_organizations_importer.rb
@@ -2,7 +2,7 @@
 
 class PureOrganizationsImporter < PureImporter
   def call
-    pbar = ProgressBar.create(title: 'Importing Pure organisational-units (organizations)', total: total_pages) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing Pure organisational-units (organizations)', total: total_pages)
     1.upto(total_pages) do |i|
       offset = (i - 1) * page_size
       organizations = get_records(type: record_type, page_size: page_size, offset: offset)
@@ -21,16 +21,16 @@ class PureOrganizationsImporter < PureImporter
                     item: item
                   })
       end
-      pbar.increment unless Rails.env.test?
+      pbar.increment
 
     rescue StandardError => e
       log_error(e, {
                   organizations: organizations
                 })
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
 
-    pbar = ProgressBar.create(title: 'Importing Pure organization relationships', total: total_pages) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing Pure organization relationships', total: total_pages)
     1.upto(total_pages) do |i|
       offset = (i - 1) * page_size
       organizations = get_records(type: record_type, page_size: page_size, offset: offset)
@@ -50,14 +50,14 @@ class PureOrganizationsImporter < PureImporter
                     item: item
                   })
       end
-      pbar.increment unless Rails.env.test?
+      pbar.increment
 
     rescue StandardError => e
       log_error(e, {
                   organizations: organizations
                 })
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
   rescue StandardError => e
     log_error(e, {})
   end

--- a/app/importers/pure_publication_importer.rb
+++ b/app/importers/pure_publication_importer.rb
@@ -4,7 +4,7 @@ class PurePublicationImporter < PureImporter
   IMPORT_SOURCE = 'Pure'
 
   def call
-    pbar = ProgressBar.create(title: 'Importing Pure research-outputs (publications)', total: total_pages) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing Pure research-outputs (publications)', total: total_pages)
 
     1.upto(total_pages) do |i|
       offset = (i - 1) * page_size
@@ -91,11 +91,11 @@ class PurePublicationImporter < PureImporter
       rescue StandardError => e
         log_error(e, { publication: publication })
       end
-      pbar.increment unless Rails.env.test?
+      pbar.increment
     rescue StandardError => e
       log_error(e, {})
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
   rescue StandardError => e
     log_error(e, {})
   end

--- a/app/importers/pure_publication_tag_importer.rb
+++ b/app/importers/pure_publication_tag_importer.rb
@@ -2,7 +2,7 @@
 
 class PurePublicationTagImporter < PureImporter
   def call
-    pbar = ProgressBar.create(title: 'Importing Pure publication tags', total: total_pages) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing Pure publication tags', total: total_pages)
 
     1.upto(total_pages) do |i|
       offset = (i - 1) * page_size
@@ -56,11 +56,11 @@ class PurePublicationTagImporter < PureImporter
                     publication: publication
                   })
       end
-      pbar.increment unless Rails.env.test?
+      pbar.increment
     rescue StandardError => e
       log_error(e, {})
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
   rescue StandardError => e
     log_error(e, {})
   end

--- a/app/importers/pure_publishers_importer.rb
+++ b/app/importers/pure_publishers_importer.rb
@@ -2,7 +2,7 @@
 
 class PurePublishersImporter < PureImporter
   def call
-    pbar = ProgressBar.create(title: 'Importing Pure publishers', total: total_pages) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing Pure publishers', total: total_pages)
 
     1.upto(total_pages) do |i|
       offset = (i - 1) * page_size
@@ -19,12 +19,12 @@ class PurePublishersImporter < PureImporter
                     item: item
                   })
       end
-      pbar.increment unless Rails.env.test?
+      pbar.increment
 
     rescue StandardError => e
       log_error(e, {})
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
   rescue StandardError => e
     log_error(e, {})
   end

--- a/app/importers/pure_user_importer.rb
+++ b/app/importers/pure_user_importer.rb
@@ -2,7 +2,7 @@
 
 class PureUserImporter < PureImporter
   def call
-    pbar = ProgressBar.create(title: 'Importing Pure persons (users)', total: total_pages) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing Pure persons (users)', total: total_pages)
 
     1.upto(total_pages) do |i|
       offset = (i - 1) * page_size
@@ -61,12 +61,12 @@ class PureUserImporter < PureImporter
                     item: item
                   })
       end
-      pbar.increment unless Rails.env.test?
+      pbar.increment
 
     rescue StandardError => e
       log_error(e, {})
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
   rescue StandardError => e
     log_error(e, {})
   end

--- a/app/importers/scholarsphere_importer.rb
+++ b/app/importers/scholarsphere_importer.rb
@@ -2,7 +2,7 @@
 
 class ScholarsphereImporter
   def call
-    pbar = ProgressBar.create(title: 'Importing ScholarSphere publication URLs', total: ss_dois.count) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing ScholarSphere publication URLs', total: ss_dois.count)
     ss_dois.each do |k, v|
       doi_url = k.gsub('doi:', 'https://doi.org/')
       matching_pubs = Publication.where(doi: doi_url)
@@ -18,7 +18,7 @@ class ScholarsphereImporter
                     publication_id: p&.id
                   })
       end
-      pbar.increment unless Rails.env.test?
+      pbar.increment
     rescue StandardError => e
       log_error(e, {
                   k: k,
@@ -26,7 +26,7 @@ class ScholarsphereImporter
                   matching_pub_ids: (binding.local_variable_get(:matching_pubs)&.map(&:id) rescue nil)
                 })
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
   rescue StandardError => e
     log_error(e, {})
   end

--- a/app/importers/unpaywall_publication_importer.rb
+++ b/app/importers/unpaywall_publication_importer.rb
@@ -2,8 +2,8 @@
 
 class UnpaywallPublicationImporter
   def import_all
-    pbar = ProgressBar.create(title: 'Importing publication data from Unpaywall',
-                              total: all_pubs.count)
+    pbar = ProgressBarTTY.create(title: 'Importing publication data from Unpaywall',
+                                 total: all_pubs.count)
 
     all_pubs.find_each do |p|
       query_unpaywall_for(p)
@@ -13,8 +13,8 @@ class UnpaywallPublicationImporter
   end
 
   def import_new
-    pbar = ProgressBar.create(title: 'Importing publication data from Unpaywall',
-                              total: new_pubs.count)
+    pbar = ProgressBarTTY.create(title: 'Importing publication data from Unpaywall',
+                                 total: new_pubs.count)
 
     new_pubs.find_each do |p|
       query_unpaywall_for(p)

--- a/app/importers/web_of_science_file_importer.rb
+++ b/app/importers/web_of_science_file_importer.rb
@@ -9,7 +9,7 @@ class WebOfScienceFileImporter
 
   def call
     import_files = Dir.children(dirname).select { |f| File.extname(f) == '.xml' }
-    pbar = ProgressBar.create(title: 'Importing Web of Science Data', total: import_files.count) unless Rails.env.test?
+    pbar = ProgressBarTTY.create(title: 'Importing Web of Science Data', total: import_files.count)
     import_files.each do |file|
       Nokogiri::XML::Reader(File.open(dirname.join(file))).each do |node|
         if node.name == 'REC' && node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
@@ -129,9 +129,9 @@ class WebOfScienceFileImporter
           end
         end
       end
-      pbar.increment unless Rails.env.test?
+      pbar.increment
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
   end
 
   private

--- a/app/models/duplicate_publication_group.rb
+++ b/app/models/duplicate_publication_group.rb
@@ -4,17 +4,15 @@ class DuplicatePublicationGroup < ApplicationRecord
   has_many :publications, inverse_of: :duplicate_group
 
   def self.group_duplicates
-    unless Rails.env.test?
-      pbar = ProgressBar.create(title: 'Grouping duplicate publications',
-                                total: Publication.count)
-    end
+    pbar = ProgressBarTTY.create(title: 'Grouping duplicate publications',
+                                 total: Publication.count)
 
     Publication.find_each do |p|
       group_duplicates_of(p)
 
-      pbar.increment unless Rails.env.test?
+      pbar.increment
     end
-    pbar.finish unless Rails.env.test?
+    pbar.finish
 
     nil
   end
@@ -60,16 +58,15 @@ class DuplicatePublicationGroup < ApplicationRecord
   end
 
   def self.auto_merge
-    unless Rails.env.test?
-      pbar = ProgressBar.create(title: 'Auto-merging Pure and AI groups',
-                                total: count)
-    end
+    pbar = ProgressBarTTY.create(title: 'Auto-merging Pure and AI groups',
+                                 total: count)
+
     find_each do |g|
       g.auto_merge
-      pbar.increment unless Rails.env.test?
+      pbar.increment
     end
 
-    pbar.finish unless Rails.env.test?
+    pbar.finish
     nil
   end
 

--- a/config/initializers/extra_requires.rb
+++ b/config/initializers/extra_requires.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_dependency Rails.root.join('lib', 'utilities', 'progressbar_tty')

--- a/lib/utilities/progressbar_tty.rb
+++ b/lib/utilities/progressbar_tty.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'ruby-progressbar/outputs/null'
+
+# This is a thin wrapper around the progressbar gem that automatically hides
+# the progressbar if the terminal is not interactive
+# (tests, nohup jobs on the server, etc)
+
+class ProgressBarTTY
+  def self.create(options = {})
+    hidden = !$stdout.tty? || Rails.env.test?
+
+    options[:output] = ProgressBar::Outputs::Null if hidden
+
+    ProgressBar.create(options)
+  end
+end


### PR DESCRIPTION
I took a crack at #292 and wrapped the`ProgressBar.create` factory in a little wrapper that tests if the current stdout is not a tty or if we are running in test mode. If either of those conditions are met, then it will use the progressbar's handy built-in Null Object for its  output instead of stdout.

There is a catch, though. The way that Adam wanted to use this in #292, by launching the script in the foreground and then backgrounding it, will not work, because the `tty?` check is only performed at initialization time. You could however do: `$ nohup bundle exec rake import:psu_identity &> /dev/null &` which would take care of things.

The above makes me think that this is ... less good than I was hoping it would turn out, but I still thought I would put it up for review before sinking any more time into it