### PR TITLE
Add a link to the user's public profile in Rails Admin

### DIFF
--- a/app/models/admin/users.rb
+++ b/app/models/admin/users.rb
@@ -18,7 +18,12 @@ module Admin::Users
             bindings[:view]._current_user.is_admin
           end
         end
-        field(:webaccess_id) { label 'Penn State WebAccess ID' }
+        field(:webaccess_id) do
+          label 'Penn State WebAccess ID'
+          pretty_value do
+            %{<a href="#{Rails.application.routes.url_helpers.profile_path(value)}" target="_blank">#{value}</a>}.html_safe if value
+          end
+        end
         field(:first_name)
         field(:middle_name)
         field(:last_name)

--- a/spec/integration/admin/users/index_spec.rb
+++ b/spec/integration/admin/users/index_spec.rb
@@ -8,8 +8,8 @@ describe 'Admin user list', type: :feature do
     before { authenticate_admin_user }
 
     describe 'the page content' do
-      let!(:user1) { create(:user, first_name: 'Bob', last_name: 'Testuser') }
-      let!(:user2) { create(:user, first_name: 'Susan', last_name: 'Tester') }
+      let!(:user1) { create(:user, first_name: 'Bob', last_name: 'Testuser', webaccess_id: 'bob') }
+      let!(:user2) { create(:user, first_name: 'Susan', last_name: 'Tester', webaccess_id: 'sue') }
 
       before { visit rails_admin.index_path(model_name: :user) }
 
@@ -34,6 +34,11 @@ describe 'Admin user list', type: :feature do
       it 'shows their status' do
         visit rails_admin.index_path(model_name: :user, set: 1)
         expect(page).to have_content 'Active?'
+      end
+
+      it "shows links to each user's public profile page" do
+        expect(page).to have_link('bob', href: '/profiles/bob')
+        expect(page).to have_link('sue', href: '/profiles/sue')
       end
     end
 


### PR DESCRIPTION
Closes #323.

When viewing the user list, clicking on the user's WebAccess ID will open a link to the user's public profile page.

<img width="1011" alt="Screen Shot 2021-11-01 at 11 36 38 AM" src="https://user-images.githubusercontent.com/639920/139698327-0221f70b-3532-49c6-8c80-be4f434e861d.png">


