### PR TITLE
Update controllers to use UserController

### DIFF
--- a/app/controllers/authorships_controller.rb
+++ b/app/controllers/authorships_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class AuthorshipsController < ApplicationController
-  before_action :authenticate_user!
-
+class AuthorshipsController < UserController
   def update
     authorship = current_user.authorships.find(params[:id])
     authorship.update!(authorship_params.merge(updated_by_owner_at: Time.current))

--- a/app/controllers/open_access_workflow_controller.rb
+++ b/app/controllers/open_access_workflow_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class OpenAccessWorkflowController < UserController
-  before_action :authenticate!
   before_action :redirect_if_inaccessible
 
   layout 'manage_profile'

--- a/app/controllers/orcid_access_tokens_controller.rb
+++ b/app/controllers/orcid_access_tokens_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class OrcidAccessTokensController < UserController
-  before_action :authenticate!
   layout 'manage_profile'
 
   def new

--- a/app/controllers/orcid_employments_controller.rb
+++ b/app/controllers/orcid_employments_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class OrcidEmploymentsController < UserController
-  before_action :authenticate!
-
   def create
     membership = current_user.user_organization_memberships.find(params[:membership_id])
 

--- a/app/controllers/orcid_works_controller.rb
+++ b/app/controllers/orcid_works_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class OrcidWorksController < UserController
-  before_action :authenticate!
-
   def create
     authorship = current_user.authorships.find(params[:authorship_id])
 

--- a/app/controllers/presentation_contributions_controller.rb
+++ b/app/controllers/presentation_contributions_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class PresentationContributionsController < ApplicationController
-  before_action :authenticate_user!
-
+class PresentationContributionsController < UserController
   def update
     contribution = current_user.presentation_contributions.find(params[:id])
     contribution.update!(contribution_params)

--- a/app/controllers/profile_management_controller.rb
+++ b/app/controllers/profile_management_controller.rb
@@ -2,7 +2,6 @@
 
 class ProfileManagementController < UserController
   layout :resolve_layout
-  before_action :authenticate!
 
   private
 

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UserController < ApplicationController
+  before_action :authenticate!
+
   private
 
     def authenticate!

--- a/app/controllers/user_performances_controller.rb
+++ b/app/controllers/user_performances_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class UserPerformancesController < ApplicationController
-  before_action :authenticate_user!
-
+class UserPerformancesController < UserController
   def update
     up = current_user.user_performances.find(params[:id])
     up.update!(up_params)

--- a/spec/component/controllers/admin/duplicate_publication_groupings_controller_spec.rb
+++ b/spec/component/controllers/admin/duplicate_publication_groupings_controller_spec.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe Admin::DuplicatePublicationGroupingsController, type: :controller do
   let!(:user) { create :user }
 
   describe '#create' do
+    let(:perform_request) { post :create, params: { user_id: user.id } }
+
+    it_behaves_like 'an unauthenticated controller'
+
     context 'when authenticated as an admin' do
       before do
         user = User.new(is_admin: true)
@@ -32,20 +37,6 @@ describe Admin::DuplicatePublicationGroupingsController, type: :controller do
 
         expect(response).to redirect_to root_path
         expect(flash[:alert]).to eq I18n.t('admin.authorization.not_authorized')
-      end
-    end
-
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        post :create, params: { user_id: user.id }
-
-        expect(response).to redirect_to root_path
-      end
-
-      it 'shows an error message' do
-        post :create, params: { user_id: user.id }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
       end
     end
   end

--- a/spec/component/controllers/admin/duplicate_publication_groups_controller_spec.rb
+++ b/spec/component/controllers/admin/duplicate_publication_groups_controller_spec.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe Admin::DuplicatePublicationGroupsController, type: :controller do
   let!(:group) { create :duplicate_publication_group }
 
   describe '#delete' do
+    let(:perform_request) { delete :delete, params: { id: 1 } }
+
+    it_behaves_like 'an unauthenticated controller'
+
     context 'when authenticated as an admin' do
       before do
         user = User.new(is_admin: true)
@@ -83,20 +88,6 @@ describe Admin::DuplicatePublicationGroupsController, type: :controller do
 
         expect(response).to redirect_to root_path
         expect(flash[:alert]).to eq I18n.t('admin.authorization.not_authorized')
-      end
-    end
-
-    context 'when not authenticated' do
-      it 'redirects to the admin home page' do
-        delete :delete, params: { id: group.id }
-
-        expect(response).to redirect_to root_path
-      end
-
-      it 'shows an error message' do
-        delete :delete, params: { id: group.id }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
       end
     end
   end

--- a/spec/component/controllers/admin/masquerade_controller_spec.rb
+++ b/spec/component/controllers/admin/masquerade_controller_spec.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe Admin::MasqueradeController, type: :controller do
   describe 'POST #become' do
-    let(:pretender) { create(:user) }
+    let(:perform_request) { post :become, params: { user_id: 1 } }
+
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
+      let(:pretender) { create(:user) }
+
       before do
         allow(request.env['warden']).to receive(:authenticate!).and_return(user)
         allow(controller).to receive(:current_user).and_return(user)
@@ -35,26 +40,16 @@ describe Admin::MasqueradeController, type: :controller do
         end
       end
     end
-
-    context 'when not authenticated' do
-      it 'redirects to the admin home page' do
-        post :become, params: { user_id: pretender.id }
-
-        expect(response).to redirect_to root_path
-      end
-
-      it 'shows an error message' do
-        post :become, params: { user_id: pretender.id }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
   end
 
   describe 'POST #unbecome' do
-    let(:pretender) { create(:user) }
+    let(:perform_request) { post :unbecome, params: { user_id: 1 } }
+
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
+      let(:pretender) { create(:user) }
+
       before do
         session[:pretend_user_id] = pretender.id
         session[:admin_user_id] = user.id
@@ -87,20 +82,6 @@ describe Admin::MasqueradeController, type: :controller do
           expect(response).to redirect_to root_path
           expect(flash[:alert]).to eq I18n.t('admin.authorization.not_authorized')
         end
-      end
-    end
-
-    context 'when not authenticated' do
-      it 'redirects to the admin home page' do
-        post :unbecome, params: { user_id: pretender.id }
-
-        expect(response).to redirect_to root_path
-      end
-
-      it 'shows an error message' do
-        post :unbecome, params: { user_id: pretender.id }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
       end
     end
   end

--- a/spec/component/controllers/admin/publication_merges_controller_spec.rb
+++ b/spec/component/controllers/admin/publication_merges_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe Admin::PublicationMergesController, type: :controller do
   let!(:group) { create :duplicate_publication_group }
@@ -8,6 +9,14 @@ describe Admin::PublicationMergesController, type: :controller do
   let!(:pub2) { create :publication, duplicate_group: group }
 
   describe '#create' do
+    let(:perform_request) do
+      post :create, params: { duplicate_publication_group_id: 1,
+                              selected_publication_ids: [2],
+                              merge_target_publication_id: 3 }
+    end
+
+    it_behaves_like 'an unauthenticated controller'
+
     context 'when authenticated as an admin' do
       before do
         user = User.new(is_admin: true)
@@ -38,24 +47,6 @@ describe Admin::PublicationMergesController, type: :controller do
 
         expect(response).to redirect_to root_path
         expect(flash[:alert]).to eq I18n.t('admin.authorization.not_authorized')
-      end
-    end
-
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        post :create, params: { duplicate_publication_group_id: group.id,
-                                selected_publication_ids: [pub1.id],
-                                merge_target_publication_id: pub2.id }
-
-        expect(response).to redirect_to root_path
-      end
-
-      it 'shows an error message' do
-        post :create, params: { duplicate_publication_group_id: group.id,
-                                selected_publication_ids: [pub1.id],
-                                merge_target_publication_id: pub2.id }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
       end
     end
   end

--- a/spec/component/controllers/admin/publication_waiver_links_controller_spec.rb
+++ b/spec/component/controllers/admin/publication_waiver_links_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe Admin::PublicationWaiverLinksController, type: :controller do
   let!(:waiver) { create :external_publication_waiver, user: user, reason_for_waiver: 'The reason' }
@@ -8,6 +9,10 @@ describe Admin::PublicationWaiverLinksController, type: :controller do
   let!(:user) { create :user }
 
   describe '#create' do
+    let(:perform_request) { post :create, params: { external_publication_waiver_id: 1 } }
+
+    it_behaves_like 'an unauthenticated controller'
+
     context 'when authenticated as an admin' do
       before do
         user = User.new(is_admin: true)
@@ -84,20 +89,6 @@ describe Admin::PublicationWaiverLinksController, type: :controller do
 
         expect(response).to redirect_to root_path
         expect(flash[:alert]).to eq I18n.t('admin.authorization.not_authorized')
-      end
-    end
-
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        post :create, params: { external_publication_waiver_id: waiver.id }
-
-        expect(response).to redirect_to root_path
-      end
-
-      it 'shows an error message' do
-        post :create, params: { external_publication_waiver_id: waiver.id }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
       end
     end
   end

--- a/spec/component/controllers/authorships_controller_spec.rb
+++ b/spec/component/controllers/authorships_controller_spec.rb
@@ -1,22 +1,15 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe AuthorshipsController, type: :controller do
+  it { is_expected.to be_a(UserController) }
+
   describe '#update' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        put :update, params: { id: 1 }
+    let(:perform_request) { put :update, params: { id: 1 } }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        put :update, params: { id: 1 }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
       let!(:user) { create :user }
@@ -66,19 +59,9 @@ describe AuthorshipsController, type: :controller do
   end
 
   describe '#sort' do
-    context 'when not authenticated' do
-      it 'redirects to the sign in page' do
-        put :sort
+    let(:perform_request) { put :sort }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        put :sort
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
       let!(:user) { create :user }

--- a/spec/component/controllers/internal_publication_waivers_controller_spec.rb
+++ b/spec/component/controllers/internal_publication_waivers_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe InternalPublicationWaiversController, type: :controller do
   let!(:user) { create :user }
@@ -40,19 +41,9 @@ describe InternalPublicationWaiversController, type: :controller do
   end
 
   describe '#new' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        get :new, params: { id: 1 }
+    let(:perform_request) { get :new, params: { id: 1 } }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        get :new, params: { id: 1 }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
       before do
@@ -118,19 +109,9 @@ describe InternalPublicationWaiversController, type: :controller do
   end
 
   describe '#create' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        get :new, params: { id: 1 }
+    let(:perform_request) { post :create, params: { id: 1 } }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        get :new, params: { id: 1 }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
       before do

--- a/spec/component/controllers/open_access_publications_controller_spec.rb
+++ b/spec/component/controllers/open_access_publications_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe OpenAccessPublicationsController, type: :controller do
   let!(:user) { create :user }
@@ -44,19 +45,9 @@ describe OpenAccessPublicationsController, type: :controller do
   end
 
   describe '#edit' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        get :edit, params: { id: 1 }
+    let(:perform_request) { get :edit, params: { id: 1 } }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        get :edit, params: { id: 1 }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
       before do
@@ -169,19 +160,9 @@ describe OpenAccessPublicationsController, type: :controller do
   end
 
   describe '#update' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        patch :update, params: { id: 1 }
+    let(:perform_request) { patch :update, params: { id: 1 } }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        patch :update, params: { id: 1 }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
       before do
@@ -325,22 +306,11 @@ describe OpenAccessPublicationsController, type: :controller do
 
   describe '#create_scholarsphere_deposit' do
     let(:found_deposit) { ScholarsphereWorkDeposit.find_by(authorship: auth) }
+    let(:perform_request) { post :create_scholarsphere_deposit, params: { id: 1 } }
 
     before { allow(ScholarsphereUploadJob).to receive(:perform_later) }
 
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        post :create_scholarsphere_deposit, params: { id: 1 }
-
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        post :create_scholarsphere_deposit, params: { id: 1 }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
       let(:now) { Time.new 2019, 1, 1, 0, 0, 0 }

--- a/spec/component/controllers/orcid_access_tokens_controller_spec.rb
+++ b/spec/component/controllers/orcid_access_tokens_controller_spec.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe OrcidAccessTokensController, type: :controller do
+  it { is_expected.to be_a(UserController) }
+
   describe '#new' do
+    let(:perform_request) { post :new }
+
+    it_behaves_like 'an unauthenticated controller'
+
     context 'when the user is authenticated' do
       let!(:user) { create :user, orcid_access_token: token }
 
@@ -38,23 +45,13 @@ describe OrcidAccessTokensController, type: :controller do
         end
       end
     end
-
-    context 'when the user is not authenticated' do
-      it 'redirects to the home page' do
-        post :new
-
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        post :new
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
   end
 
   describe '#create' do
+    let(:perform_request) { get :create }
+
+    it_behaves_like 'an unauthenticated controller'
+
     context 'when the user is authenticated' do
       let(:client) { double 'ORCID Oauth client' }
       let!(:user) { create :user }
@@ -125,20 +122,6 @@ describe OrcidAccessTokensController, type: :controller do
             expect(response).to redirect_to profile_bio_path
           end
         end
-      end
-    end
-
-    context 'when the user is not authenticated' do
-      it 'redirects to the home page' do
-        get :create
-
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        get :create
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
       end
     end
   end

--- a/spec/component/controllers/orcid_employments_controller_spec.rb
+++ b/spec/component/controllers/orcid_employments_controller_spec.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe OrcidEmploymentsController, type: :controller do
+  it { is_expected.to be_a(UserController) }
+
   describe '#create' do
+    let(:perform_request) { post :create, params: { membership_id: '2' } }
+
+    it_behaves_like 'an unauthenticated controller'
+
     context 'when the user is authenticated' do
       let!(:user) { create :user }
       let(:employment) { double 'ORCID employment', save!: nil, location: 'the_location' }
@@ -94,18 +101,6 @@ describe OrcidEmploymentsController, type: :controller do
         it 'redirects back to the profile bio page' do
           expect(response).to redirect_to profile_bio_path
         end
-      end
-    end
-
-    context 'when the user is not authenticated' do
-      it 'redirects to the home page' do
-        post :create, params: { membership_id: '2' }
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        post :create, params: { membership_id: '2' }
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
       end
     end
   end

--- a/spec/component/controllers/orcid_works_controller_spec.rb
+++ b/spec/component/controllers/orcid_works_controller_spec.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe OrcidWorksController, type: :controller do
+  it { is_expected.to be_a(UserController) }
+
   describe '#create' do
+    let(:perform_request) { post :create }
+
+    it_behaves_like 'an unauthenticated controller'
+
     context 'when the user is authenticated' do
       let!(:user) { create :user }
       let(:work) { double 'ORCID work', save!: nil, location: 'the_location' }
@@ -94,18 +101,6 @@ describe OrcidWorksController, type: :controller do
         it 'redirects back to the profile bio page' do
           expect(response).to redirect_to edit_profile_publications_path
         end
-      end
-    end
-
-    context 'when the user is not authenticated' do
-      it 'redirects to the home page' do
-        post :create
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        post :create
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
       end
     end
   end

--- a/spec/component/controllers/presentation_contributions_controller_spec.rb
+++ b/spec/component/controllers/presentation_contributions_controller_spec.rb
@@ -1,22 +1,15 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe PresentationContributionsController, type: :controller do
+  it { is_expected.to be_a(UserController) }
+
   describe '#update' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        put :update, params: { id: 1 }
+    let(:perform_request) { put :update, params: { id: 1 } }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        put :update, params: { id: 1 }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
       let!(:user) { create :user }
@@ -60,19 +53,9 @@ describe PresentationContributionsController, type: :controller do
   end
 
   describe '#sort' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        put :sort
+    let(:perform_request) { put :sort }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        put :sort
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
       let!(:user) { create :user }

--- a/spec/component/controllers/profiles_controller_spec.rb
+++ b/spec/component/controllers/profiles_controller_spec.rb
@@ -1,69 +1,30 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe ProfilesController, type: :controller do
   describe '#edit_publications' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        get :edit_publications
+    let(:perform_request) { get :edit_publications }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        get :edit_publications
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
   end
 
   describe '#edit_presentations' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        get :edit_presentations
+    let(:perform_request) { get :edit_presentations }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        get :edit_presentations
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
   end
 
   describe '#edit_performances' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        get :edit_performances
+    let(:perform_request) { get :edit_performances }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        get :edit_performances
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
   end
 
   describe '#edit_other_publications' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        get :edit_other_publications
+    let(:perform_request) { get :edit_other_publications }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        get :edit_other_publications
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
   end
 end

--- a/spec/component/controllers/shared_examples_for_an_unauthenticated_controller.rb
+++ b/spec/component/controllers/shared_examples_for_an_unauthenticated_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+shared_examples_for 'an unauthenticated controller' do
+  before do
+    raise 'perform_request must be set with `let(:perform_request)`' unless defined? perform_request
+  end
+
+  context 'when the user is not authenticated' do
+    before { perform_request }
+
+    it 'redirects to the home page' do
+      expect(response).to redirect_to root_path
+    end
+
+    it 'sets a flash error message' do
+      expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
+    end
+  end
+end

--- a/spec/component/controllers/user_controller_spec.rb
+++ b/spec/component/controllers/user_controller_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
+
+describe UserController, type: :controller do
+  controller do
+    def index
+      current_user
+      render plain: 'OK'
+    end
+  end
+
+  let(:perform_request) { get :index }
+
+  it_behaves_like 'an unauthenticated controller'
+
+  # @note To avoid having to dig into Devise to mimic its current_user behavior, we're just testing that our builder
+  # class gets called. The actual user that get returned is test within that builder's spec test, as well as integration
+  # tests where the user is pretending to be someone else. Here, all we're concerned about is did the controller call
+  # the builder to set the current user.
+  context 'when setting the current user' do
+    before do
+      allow(CurrentUserBuilder).to receive(:call)
+      allow(request.env['warden']).to receive(:authenticate!)
+    end
+
+    it 'sets the current user to the user' do
+      perform_request
+      expect(CurrentUserBuilder).to have_received(:call)
+      expect(request.env['warden']).to have_received(:authenticate!)
+    end
+  end
+end

--- a/spec/component/controllers/user_performances_controller_spec.rb
+++ b/spec/component/controllers/user_performances_controller_spec.rb
@@ -1,22 +1,15 @@
 # frozen_string_literal: true
 
 require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
 
 describe UserPerformancesController, type: :controller do
+  it { is_expected.to be_a(UserController) }
+
   describe '#update' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        put :update, params: { id: 1 }
+    let(:perform_request) { put :update, params: { id: 1 } }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        put :update, params: { id: 1 }
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
       let!(:user) { create :user }
@@ -60,19 +53,9 @@ describe UserPerformancesController, type: :controller do
   end
 
   describe '#sort' do
-    context 'when not authenticated' do
-      it 'redirects to the home page' do
-        put :sort
+    let(:perform_request) { put :sort }
 
-        expect(response).to redirect_to root_path
-      end
-
-      it 'sets a flash error message' do
-        put :sort
-
-        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
-      end
-    end
+    it_behaves_like 'an unauthenticated controller'
 
     context 'when authenticated' do
       let!(:user) { create :user }


### PR DESCRIPTION
Controllers that perform `authenticate_user!` need to consistently set the `current_user`, whether this is the actual user, or an admin impersonating them. The inheritances are shuffled a bit so that any controller authenticating a user will subclass `UserController`. There are also additional refactorings, bringing all the unauthenticated controller tests into on shared test.
Controllers that subclass `UserController` just have a simple type check. Then the actual user controller spec test verifies that the builder class is used to set the current user. 

Although this fixes the underlying issue in this ticket, there aren't any integration tests that verify it because the only thing that's changing is the current user. Since the builder class tests that thoroughly, and we now verify that the other controllers will use that class, further integration tests seem unnecessary.

Fixes #322 