### PR TITLE
Allow any Penn State user to create an account

### DIFF
--- a/spec/fixtures/vcr_cassettes/User/_attributes_from_psu_identity/when_identity_data_is_not_present/does_not_change_the_user_s_attributes.yml
+++ b/spec/fixtures/vcr_cassettes/User/_attributes_from_psu_identity/when_identity_data_is_not_present/does_not_change_the_user_s_attributes.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people/userid/idonotexist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 02 Nov 2021 17:28:48 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '124'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=ofqxqhtgJLo0sPBnduzHQBD0BfygyzxXDp2nfquJ.search-service-77488f987b-86bbc;
+        path=/search-service
+      X-Request-Id:
+      - 5047fd195cc751ceda30bcc41505c8d9
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - dd7cd459-7fd2-49ae-b9f6-77e907627193
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"status":{"code":404,"message":"NOT_FOUND"},"errorMessage":["No person
+        matched the input userid: idonotexist"],"link":null}'
+  recorded_at: Tue, 02 Nov 2021 17:28:50 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/User/_attributes_from_psu_identity/when_identity_data_is_present/sets_the_user_s_attributes_using_data_from_Penn_State.yml
+++ b/spec/fixtures/vcr_cassettes/User/_attributes_from_psu_identity/when_identity_data_is_present/sets_the_user_s_attributes_using_data_from_Penn_State.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people/userid/agw13
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 Nov 2021 17:28:48 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '357'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=iwMCKfU6dGOYERIlJqb4Lud5oHZjvjl9-Z0VEH5x.search-service-77488f987b-hfzhk;
+        path=/search-service
+      X-Request-Id:
+      - 43e12c56fac516ed3a8b82079551cefb
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - 704174de-801a-400f-92d9-2148f6ef9b91
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"userid":"agw13","cprid":"2784093","givenName":"Adam","middleName":"Garner","familyName":"Wead","preferredGivenName":"Adam","preferredFamilyName":"Wead","active":true,"confHold":false,"universityEmail":"agw13@psu.edu","serviceAccount":false,"affiliation":["STAFF"],"displayName":"Adam
+        Wead","link":{"href":"https://dev.apps.psu.edu/cpr/resources/2784093"}}'
+  recorded_at: Tue, 02 Nov 2021 17:28:50 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/User/_from_omniauth/when_given_an_auth_object_with_a_UID_that_does_not_match_a_user_in_the_database/adds_a_new_user.yml
+++ b/spec/fixtures/vcr_cassettes/User/_from_omniauth/when_given_an_auth_object_with_a_UID_that_does_not_match_a_user_in_the_database/adds_a_new_user.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people/userid/agw13
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 Nov 2021 17:16:28 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '357'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=JLPsupZPYOwRpHWqHPyQ-IFistdBLAvdbPNdkiG-.search-service-77488f987b-86bbc;
+        path=/search-service
+      X-Request-Id:
+      - 0c7b64a430b3e13c11e1940cdf675a36
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - 6f4293ec-d3f6-4d7d-bd67-9f7f2e3ebd36
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"userid":"agw13","cprid":"2784093","givenName":"Adam","middleName":"Garner","familyName":"Wead","preferredGivenName":"Adam","preferredFamilyName":"Wead","active":true,"confHold":false,"universityEmail":"agw13@psu.edu","serviceAccount":false,"affiliation":["STAFF"],"displayName":"Adam
+        Wead","link":{"href":"https://dev.apps.psu.edu/cpr/resources/2784093"}}'
+  recorded_at: Tue, 02 Nov 2021 17:16:30 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
After authenticating with Azure, if the user is not present in RMD, an account will be created for them using their current identity data from Penn State. Only the minimal amount of information will be stored, and the user will have no organizational memberships.

I have verified that users can submit open access waiver forms via the Publications tab, but there are no additional integration tests needed for that because we don't distinguish between users created via import or users created via direct login.

FIxes #267 