### PR TITLE
Create a DeputyAssignment to assign delegate users

### DIFF
--- a/app/models/deputy_assignment.rb
+++ b/app/models/deputy_assignment.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class DeputyAssignment < ApplicationRecord
+  belongs_to :primary,
+             class_name: 'User',
+             foreign_key: :primary_user_id,
+             inverse_of: :primary_assignments
+
+  belongs_to :deputy,
+             class_name: 'User',
+             foreign_key: :deputy_user_id,
+             inverse_of: :deputy_assignments
+
+  validate :primary_and_deputy_cannot_be_the_same,
+           :admins_cannot_be_assigned
+
+  validates :deputy, uniqueness: { scope: [:primary] }
+
+  private
+
+    def primary_and_deputy_cannot_be_the_same
+      errors.add(:deputy, :same_as_primary) if primary == deputy && primary.present?
+    end
+
+    def admins_cannot_be_assigned
+      errors.add(:primary, :is_admin) if primary&.admin?
+      errors.add(:deputy, :is_admin) if deputy&.admin?
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,20 @@ class User < ApplicationRecord
   has_many :external_publication_waivers
   has_many :contributor_names
 
+  has_many :primary_assignments,
+           class_name: :DeputyAssignment,
+           foreign_key: :primary_user_id,
+           inverse_of: :primary,
+           dependent: :destroy
+  has_many :deputies, through: :primary_assignments
+
+  has_many :deputy_assignments,
+           class_name: :DeputyAssignment,
+           foreign_key: :deputy_user_id,
+           inverse_of: :deputy,
+           dependent: :destroy
+  has_many :primaries, through: :deputy_assignments
+
   scope :active, -> { where.not(psu_identity: nil).where("psu_identity->'data'->>'affiliation' != '[\"MEMBER\"]'") }
 
   accepts_nested_attributes_for :user_organization_memberships, allow_destroy: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,17 @@ en:
     attributes:
       open_access_url_form:
         open_access_url: "URL"
+  activerecord:
+    errors:
+      models:
+        deputy_assignment:
+          attributes:
+            deputy:
+              same_as_primary: 'cannot be the same as the primary user'
+              taken: 'has already been assigned to this user'
+              is_admin: 'cannot be an administrator'
+            primary:
+              is_admin: 'cannot be an administrator'
   admin:
     authorization:
       not_authorized: "Your account is not authorized to perform this action."

--- a/db/migrate/20211102184914_create_deputy_assignments.rb
+++ b/db/migrate/20211102184914_create_deputy_assignments.rb
@@ -1,0 +1,15 @@
+class CreateDeputyAssignments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :deputy_assignments do |t|
+      t.references :primary_user, references: :users, foreign_key: { to_table: :users }
+      t.references :deputy_user, references: :users, foreign_key: { to_table: :users }
+      t.timestamp :deactivated_at, null: true
+      t.boolean :is_active
+      t.timestamp :confirmed_at, null: true
+
+      t.timestamps
+    end
+
+    add_index :deputy_assignments, [:primary_user_id, :deputy_user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -107,6 +107,19 @@ ActiveRecord::Schema.define(version: 2021_11_03_180127) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
+  create_table "deputy_assignments", force: :cascade do |t|
+    t.bigint "primary_user_id"
+    t.bigint "deputy_user_id"
+    t.datetime "deactivated_at"
+    t.boolean "is_active"
+    t.datetime "confirmed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deputy_user_id"], name: "index_deputy_assignments_on_deputy_user_id"
+    t.index ["primary_user_id", "deputy_user_id"], name: "index_deputy_assignments_on_primary_user_id_and_deputy_user_id", unique: true
+    t.index ["primary_user_id"], name: "index_deputy_assignments_on_primary_user_id"
+  end
+
   create_table "duplicate_publication_groups", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -590,6 +603,8 @@ ActiveRecord::Schema.define(version: 2021_11_03_180127) do
   add_foreign_key "contract_imports", "contracts", on_delete: :cascade
   add_foreign_key "contributor_names", "publications", on_delete: :cascade
   add_foreign_key "contributor_names", "users"
+  add_foreign_key "deputy_assignments", "users", column: "deputy_user_id"
+  add_foreign_key "deputy_assignments", "users", column: "primary_user_id"
   add_foreign_key "education_history_items", "users", on_delete: :cascade
   add_foreign_key "email_errors", "users", name: "email_errors_user_id_fk"
   add_foreign_key "external_publication_waivers", "internal_publication_waivers", name: "external_publication_waivers_internal_publication_waiver_id_fk"

--- a/spec/component/models/deputy_assignment_spec.rb
+++ b/spec/component/models/deputy_assignment_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+require 'component/models/shared_examples_for_an_application_record'
+
+describe 'the deputy assignments table', type: :model do
+  subject(:user) { DeputyAssignment.new }
+
+  it { is_expected.to have_db_column(:primary_user_id).of_type(:integer) }
+  it { is_expected.to have_db_column(:deputy_user_id).of_type(:integer) }
+  it { is_expected.to have_db_column(:deactivated_at).of_type(:datetime) }
+  it { is_expected.to have_db_column(:confirmed_at).of_type(:datetime) }
+  it { is_expected.to have_db_column(:is_active).of_type(:boolean) }
+  it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
+  it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+
+  it { is_expected.to have_db_index(:deputy_user_id) }
+  it { is_expected.to have_db_index(:primary_user_id) }
+  it { is_expected.to have_db_index([:primary_user_id, :deputy_user_id]).unique(true) }
+end
+
+describe DeputyAssignment, type: :model do
+  subject(:user) { described_class.new }
+
+  it_behaves_like 'an application record'
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:primary).class_name('User') }
+    it { is_expected.to belong_to(:deputy).class_name('User') }
+  end
+
+  describe 'validations' do
+    let(:primary_user) { create(:user) }
+    let(:deputy_user) { create(:user) }
+    let(:admin_user) { create(:user, is_admin: true) }
+
+    it 'validates that primary and deputy are different' do
+      assignment = described_class.create(primary: primary_user)
+      expect(assignment).to allow_value(deputy_user).for(:deputy)
+      expect(assignment).not_to allow_value(primary_user).for(:deputy)
+      message = I18n.t!('activerecord.errors.models.deputy_assignment.attributes.deputy.same_as_primary')
+      expect(assignment.errors[:deputy]).to include(message)
+    end
+
+    it 'validates that a primary cannot have the same deputy twice' do
+      described_class.create!(primary: primary_user, deputy: deputy_user)
+      assignment = described_class.new(primary: primary_user, deputy: deputy_user)
+      expect(assignment).not_to be_valid
+      message = I18n.t!('activerecord.errors.models.deputy_assignment.attributes.deputy.taken')
+      expect(assignment.errors[:deputy]).to include(message)
+    end
+
+    it 'validates admins cannot be deputies' do
+      assignment = described_class.new
+      expect(assignment).not_to allow_value(admin_user).for(:deputy)
+      message = I18n.t!('activerecord.errors.models.deputy_assignment.attributes.deputy.is_admin')
+      expect(assignment.errors[:deputy]).to include(message)
+    end
+
+    it 'validates admins cannot be primaries' do
+      assignment = described_class.new
+      expect(assignment).not_to allow_value(admin_user).for(:primary)
+      message = I18n.t!('activerecord.errors.models.deputy_assignment.attributes.primary.is_admin')
+      expect(assignment.errors[:primary]).to include(message)
+    end
+  end
+
+  context 'when a primary user has a deputy' do
+    let(:primary_user) { create(:user) }
+    let(:deputy_user) { create(:user) }
+    let(:assignment) { described_class.create(primary: primary_user, deputy: deputy_user) }
+
+    specify do
+      expect(assignment.primary).to eq(primary_user)
+      expect(assignment.deputy).to eq(deputy_user)
+    end
+  end
+end

--- a/spec/component/models/user_spec.rb
+++ b/spec/component/models/user_spec.rb
@@ -87,6 +87,10 @@ describe User, type: :model do
     it { is_expected.to have_many(:grants).through(:researcher_funds) }
     it { is_expected.to have_many(:external_publication_waivers) }
     it { is_expected.to have_many(:contributor_names) }
+    it { is_expected.to have_many(:primary_assignments).class_name(:DeputyAssignment).with_foreign_key(:primary_user_id) }
+    it { is_expected.to have_many(:deputies).through(:primary_assignments) }
+    it { is_expected.to have_many(:deputy_assignments).class_name(:DeputyAssignment).with_foreign_key(:deputy_user_id) }
+    it { is_expected.to have_many(:primaries).through(:deputy_assignments) }
   end
 
   describe 'validations' do
@@ -1681,6 +1685,48 @@ describe User, type: :model do
       let(:user) { build(:user, :with_psu_member_affiliation) }
 
       it { is_expected.not_to be_active }
+    end
+  end
+
+  describe '#deputies' do
+    subject(:user) { build(:user, deputies: [deputy]) }
+
+    let(:deputy) { build(:user) }
+
+    its(:deputies) { is_expected.to contain_exactly(deputy) }
+
+    context 'when deleting' do
+      before { user.save! }
+
+      it 'deletes the deputy and the relationship' do
+        expect(user).to be_persisted
+        expect(deputy).to be_persisted
+        deputy.destroy!
+        expect(user).to be_persisted
+        expect(deputy).not_to be_persisted
+        expect(user.reload.deputies).to be_empty
+      end
+    end
+  end
+
+  describe '#primaries' do
+    subject(:user) { build(:user, primaries: [primary]) }
+
+    let(:primary) { build(:user) }
+
+    its(:primaries) { is_expected.to contain_exactly(primary) }
+
+    context 'when deleting' do
+      before { user.save! }
+
+      it 'deletes the primary and the relationship' do
+        expect(user).to be_persisted
+        expect(primary).to be_persisted
+        primary.destroy!
+        expect(user).to be_persisted
+        expect(primary).not_to be_persisted
+        expect(user.reload.primaries).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
A user (primary) may assign a delegate (deputy) in order to allow that user to act on their behalf. The deputy may then upload articles, submit waivers, or otherwise interact with the application as if they were logged in as the primary user.

This creates a join table, deputy_assignments, that links a user with their deputies, and notes whether or not they are active and if they have confirmed their willingness to be this user's delegate.

Validations restrict delegates to non-admin users and prevent a user from having the same delegate listed more than once.

Fixes #320 
Fixes #215 