### PR TITLE
Allow deputies to become/unbecome their primaries

### DIFF
--- a/app/controllers/admin/masquerade_controller.rb
+++ b/app/controllers/admin/masquerade_controller.rb
@@ -2,22 +2,6 @@
 
 module Admin
   class MasqueradeController < RailsAdmin::ApplicationController
-    def become
-      session[:pretend_user_id] = pretender.id
-      session[:admin_user_id] = current_user.id
-      redirect_to main_app.profile_path(pretender.webaccess_id)
-    end
-
-    def unbecome
-      session.delete(:pretend_user_id)
-      session.delete(:admin_user_id)
-      redirect_to main_app.profile_path(pretender.webaccess_id)
-    end
-
-    private
-
-      def pretender
-        @pretender ||= User.find(params[:user_id])
-      end
+    include ::MasqueradingBehaviors
   end
 end

--- a/app/controllers/concerns/masquerading_behaviors.rb
+++ b/app/controllers/concerns/masquerading_behaviors.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module MasqueradingBehaviors
+  extend ActiveSupport::Concerns
+
+  SESSION_ID = :primary_user_id
+
+  def become
+    session[SESSION_ID] = primary_user.id
+    redirect_to main_app.profile_path(primary_user.webaccess_id)
+  end
+
+  def unbecome
+    session.delete(SESSION_ID)
+    redirect_to main_app.profile_path(primary_user.webaccess_id)
+  end
+
+  private
+
+    def primary_user
+      @primary_user ||= User.find(params[:user_id])
+    end
+end

--- a/app/controllers/masquerade_controller.rb
+++ b/app/controllers/masquerade_controller.rb
@@ -8,7 +8,7 @@ class MasqueradeController < UserController
   private
 
     def verify_deputies
-      return if primary_user.available_deputies.include?(current_user)
+      return if primary_user.available_deputy?(current_user)
 
       flash[:alert] = I18n.t('profile.errors.not_authorized')
       redirect_to root_path

--- a/app/controllers/masquerade_controller.rb
+++ b/app/controllers/masquerade_controller.rb
@@ -8,7 +8,7 @@ class MasqueradeController < UserController
   private
 
     def verify_deputies
-      return if primary_user.deputies.include?(current_user)
+      return if primary_user.available_deputies.include?(current_user)
 
       flash[:alert] = I18n.t('profile.errors.not_authorized')
       redirect_to root_path

--- a/app/controllers/masquerade_controller.rb
+++ b/app/controllers/masquerade_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class MasqueradeController < UserController
+  include MasqueradingBehaviors
+
+  before_action :verify_deputies
+
+  private
+
+    def verify_deputies
+      return if primary_user.deputies.include?(current_user)
+
+      flash[:alert] = I18n.t('profile.errors.not_authorized')
+      redirect_to root_path
+    end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -35,11 +35,39 @@ class ProfilesController < ProfileManagementController
     @memberships = current_user.user_organization_memberships
   end
 
-  helper_method :profile_for_current_user?
+  helper_method :profile_for_current_user?,
+                :masquerading?,
+                :deputized?,
+                :path_to_become_user,
+                :path_to_unbecome_user
 
   private
 
     def profile_for_current_user?
       current_user && current_user.webaccess_id == params[:webaccess_id]
+    end
+
+    def masquerading?
+      current_user.masquerading?
+    end
+
+    def deputized?
+      current_user.admin? || @profile.available_deputy?(current_user)
+    end
+
+    def path_to_become_user
+      if current_user.admin?
+        admin_becomes_user_path(@profile.id)
+      else
+        becomes_user_path(@profile.id)
+      end
+    end
+
+    def path_to_unbecome_user
+      if current_user.admin?
+        admin_unbecomes_user_path(current_user)
+      else
+        unbecomes_user_path(current_user)
+      end
     end
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -11,6 +11,8 @@ class UserController < ApplicationController
     end
 
     def current_user
-      @current_user ||= CurrentUserBuilder.call(current_user: super, current_session: session)
+      @current_user ||= super
+
+      CurrentUserBuilder.call(current_user: @current_user, current_session: session)
     end
 end

--- a/app/models/deputy_assignment.rb
+++ b/app/models/deputy_assignment.rb
@@ -39,6 +39,7 @@ class DeputyAssignment < ApplicationRecord
              inverse_of: :deputy_assignments
 
   scope :active, -> { where(is_active: true) }
+  scope :confirmed, -> { where.not(confirmed_at: nil) }
 
   validate :primary_and_deputy_cannot_be_the_same,
            :admins_cannot_be_assigned

--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -2,4 +2,8 @@
 
 class NullUser
   include NullObjectPattern
+
+  def deputies
+    []
+  end
 end

--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -2,9 +2,4 @@
 
 class NullUser
   include NullObjectPattern
-
-  def deputies
-    []
-  end
-  alias :available_deputies :deputies
 end

--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -6,4 +6,5 @@ class NullUser
   def deputies
     []
   end
+  alias :available_deputies :deputies
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,12 +142,12 @@ class User < ApplicationRecord
     is_active
   end
 
-  def available_deputies
-    self
-      .class
-      .joins(:deputy_assignments)
-      .where(deputy_assignments: { primary_user_id: id, is_active: true, deactivated_at: nil })
-      .where.not(deputy_assignments: { confirmed_at: nil })
+  def available_deputy?(other_user)
+    primary_assignments
+      .where(deputy: other_user)
+      .active
+      .confirmed
+      .any?
   end
 
   def update_psu_identity

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,6 +142,14 @@ class User < ApplicationRecord
     is_active
   end
 
+  def available_deputies
+    self
+      .class
+      .joins(:deputy_assignments)
+      .where(deputy_assignments: { primary_user_id: id, is_active: true, deactivated_at: nil })
+      .where.not(deputy_assignments: { confirmed_at: nil })
+  end
+
   def update_psu_identity
     update(psu_identity: psu_identity_data, psu_identity_updated_at: Time.zone.now)
   end

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -7,6 +7,7 @@ class UserProfile
   end
 
   delegate :active?,
+           :available_deputy?,
            :id,
            :name,
            :office_location,

--- a/app/services/current_user_builder.rb
+++ b/app/services/current_user_builder.rb
@@ -14,7 +14,7 @@ class CurrentUserBuilder
 
     user = User.find(current_session[MasqueradingBehaviors::SESSION_ID]) || NullUser.new
 
-    if current_user.admin? || user.available_deputies.include?(current_user)
+    if current_user.admin? || user.available_deputy?(current_user)
       UserDecorator.new(
         user: user,
         impersonator: current_user

--- a/app/services/current_user_builder.rb
+++ b/app/services/current_user_builder.rb
@@ -1,12 +1,22 @@
 # frozen_string_literal: true
 
+# @abstract A builder service that returns a UserDecorator as the current_user for a session.  The service determines if
+# the user who is presently authenticated is impersonating another user or not. If they are, it checks to see if they
+# are allowed to, and returns the appropriate decorator.
+
 class CurrentUserBuilder
+  # @param current_user [User, nil]
+  # @param current_session [Hash]
+  # @return UserDecorator
   def self.call(current_user:, current_session:)
     return NullUser.new if current_user.nil?
+    return UserDecorator.new(user: current_user) unless current_session.key?(MasqueradingBehaviors::SESSION_ID)
 
-    if current_user.admin? && current_session.key?(:pretend_user_id)
+    user = User.find(current_session[MasqueradingBehaviors::SESSION_ID]) || NullUser.new
+
+    if current_user.admin? || user.deputies.include?(current_user)
       UserDecorator.new(
-        user: User.find(current_session[:pretend_user_id]),
+        user: user,
         impersonator: current_user
       )
     else

--- a/app/services/current_user_builder.rb
+++ b/app/services/current_user_builder.rb
@@ -14,7 +14,7 @@ class CurrentUserBuilder
 
     user = User.find(current_session[MasqueradingBehaviors::SESSION_ID]) || NullUser.new
 
-    if current_user.admin? || user.deputies.include?(current_user)
+    if current_user.admin? || user.available_deputies.include?(current_user)
       UserDecorator.new(
         user: user,
         impersonator: current_user

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -80,16 +80,17 @@
               <% end %>
             <% end %>
           </div>
+
           <% if profile_for_current_user? %>
             <%= link_to "Manage my profile", profile_bio_path, class: 'button' %>
           <% end %>
-          <% if current_user.masquerading? %>
-            <%= link_to "Unbecome this user", admin_unbecomes_user_path(current_user),
-              class: 'button', method: :post %>
-          <% elsif current_user.admin? %>
-            <%= link_to "Become this user", admin_becomes_user_path(@profile.id),
-              class: 'button', method: :post %>
+
+          <% if masquerading? %>
+            <%= link_to "Unbecome this user", path_to_unbecome_user, class: 'button', method: :post %>
+          <% elsif deputized? %>
+            <%= link_to "Become this user", path_to_become_user, class: 'button', method: :post %>
           <% end %>
+
         </div>
         <% if @profile.research_interests %>
           <div class="research">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,8 @@ en:
         support: Support
         sign_out: Sign out
   profile:
+    errors:
+      not_authorized: "Your account is not authorized to perform this action"
     open_access_publications:
       update:
         success: "Thank you for taking the time to submit your open access URL. It was successfully saved."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,8 @@ Rails.application.routes.draw do
     post 'publications/:id/open_access/waivers' => 'internal_publication_waivers#create', as: :internal_publication_waivers
     get 'publications/open_access_waivers/new' => 'external_publication_waivers#new', as: :new_external_publication_waiver
     post 'publications/open_access_waivers' => 'external_publication_waivers#create', as: :external_publication_waivers
+    post 'unbecome/:user_id' => 'masquerade#unbecome', as: :unbecomes_user
+    post 'become/:user_id' => 'masquerade#become', as: :becomes_user
   end
 
   post 'orcid_access_token' => 'orcid_access_tokens#new', as: :new_orcid_access_token

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,24 +47,27 @@ Rails.application.routes.draw do
   end
 
   get 'profiles/:webaccess_id' => 'profiles#show', as: :profile
-  get 'profile/publications/edit' => 'profiles#edit_publications', as: :edit_profile_publications
-  get 'profile/presentations/edit' => 'profiles#edit_presentations', as: :edit_profile_presentations
-  get 'profile/performances/edit' => 'profiles#edit_performances', as: :edit_profile_performances
-  get 'profile/other_publications/edit' => 'profiles#edit_other_publications', as: :edit_profile_other_publications
-  get 'profile/bio' => 'profiles#bio', as: :profile_bio
-  post 'profile/bio/orcid/employments/:membership_id' => 'orcid_employments#create', as: :orcid_employments
-  post 'profile/bio/orcid/works' => 'orcid_works#create', as: :orcid_works
-  get 'profile/publications/:id/open_access/edit' => 'open_access_publications#edit', as: :edit_open_access_publication
-  patch 'profile/publications/:id/open_access' => 'open_access_publications#update', as: :open_access_publication
-  post 'profile/publications/:id/open_access/scholarsphere_deposit' => 'open_access_publications#create_scholarsphere_deposit', as: :scholarsphere_deposit
-  get 'profile/publications/:id/open_access/waivers/new' => 'internal_publication_waivers#new', as: :new_internal_publication_waiver
-  post 'profile/publications/:id/open_access/waivers' => 'internal_publication_waivers#create', as: :internal_publication_waivers
-  get 'profile/publications/open_access_waivers/new' => 'external_publication_waivers#new', as: :new_external_publication_waiver
-  post 'profile/publications/open_access_waivers' => 'external_publication_waivers#create', as: :external_publication_waivers
-  post 'orcid_access_token' => 'orcid_access_tokens#new', as: :new_orcid_access_token
-  get 'orcid_access_token' => 'orcid_access_tokens#create', as: :orcid_access_token
 
   get 'profile' => redirect('profile/publications/edit')
+  scope 'profile' do
+    get 'publications/edit' => 'profiles#edit_publications', as: :edit_profile_publications
+    get 'presentations/edit' => 'profiles#edit_presentations', as: :edit_profile_presentations
+    get 'performances/edit' => 'profiles#edit_performances', as: :edit_profile_performances
+    get 'other_publications/edit' => 'profiles#edit_other_publications', as: :edit_profile_other_publications
+    get 'bio' => 'profiles#bio', as: :profile_bio
+    post 'bio/orcid/employments/:membership_id' => 'orcid_employments#create', as: :orcid_employments
+    post 'bio/orcid/works' => 'orcid_works#create', as: :orcid_works
+    get 'publications/:id/open_access/edit' => 'open_access_publications#edit', as: :edit_open_access_publication
+    patch 'publications/:id/open_access' => 'open_access_publications#update', as: :open_access_publication
+    post 'publications/:id/open_access/scholarsphere_deposit' => 'open_access_publications#create_scholarsphere_deposit', as: :scholarsphere_deposit
+    get 'publications/:id/open_access/waivers/new' => 'internal_publication_waivers#new', as: :new_internal_publication_waiver
+    post 'publications/:id/open_access/waivers' => 'internal_publication_waivers#create', as: :internal_publication_waivers
+    get 'publications/open_access_waivers/new' => 'external_publication_waivers#new', as: :new_external_publication_waiver
+    post 'publications/open_access_waivers' => 'external_publication_waivers#create', as: :external_publication_waivers
+  end
+
+  post 'orcid_access_token' => 'orcid_access_tokens#new', as: :new_orcid_access_token
+  get 'orcid_access_token' => 'orcid_access_tokens#create', as: :orcid_access_token
 
   get 'proxies' => 'deputy_assignments#index', as: :deputy_assignments
   post 'proxies' => 'deputy_assignments#create'

--- a/spec/component/models/deputy_assignment_spec.rb
+++ b/spec/component/models/deputy_assignment_spec.rb
@@ -40,6 +40,16 @@ describe DeputyAssignment, type: :model do
         expect(described_class.active).to contain_exactly(active)
       end
     end
+
+    describe '.confirmed' do
+      let!(:confirmed) { create :deputy_assignment, confirmed_at: Time.zone.now - 1.day }
+
+      before { create :deputy_assignment, confirmed_at: nil }
+
+      it 'returns confirmed models' do
+        expect(described_class.confirmed).to contain_exactly(confirmed)
+      end
+    end
   end
 
   describe 'validations' do

--- a/spec/component/models/user_profile_spec.rb
+++ b/spec/component/models/user_profile_spec.rb
@@ -16,6 +16,7 @@ describe UserProfile do
                        ai_research_interests: 'test research interests' }
 
   it { is_expected.to delegate_method(:active?).to(:user) }
+  it { is_expected.to delegate_method(:available_deputy?).to(:user) }
   it { is_expected.to delegate_method(:id).to(:user) }
   it { is_expected.to delegate_method(:name).to(:user) }
   it { is_expected.to delegate_method(:office_location).to(:user) }

--- a/spec/component/models/user_spec.rb
+++ b/spec/component/models/user_spec.rb
@@ -1709,6 +1709,22 @@ describe User, type: :model do
     end
   end
 
+  describe '#available_deputies' do
+    let(:user) { create(:user, primary_assignments: [available_assignment, unconfirmed_assignment, inactive_assignment]) }
+    let(:available_assignment) { create(:deputy_assignment, :active) }
+    let(:unconfirmed_assignment) { create(:deputy_assignment, :unconfirmed) }
+    let(:inactive_assignment) { create(:deputy_assignment, :inactive) }
+
+    it 'limits the available deputies to those that are active and confirmed' do
+      expect(user.deputies).to contain_exactly(
+        available_assignment.deputy,
+        unconfirmed_assignment.deputy,
+        inactive_assignment.deputy
+      )
+      expect(user.available_deputies).to contain_exactly(available_assignment.deputy)
+    end
+  end
+
   describe '#primaries' do
     subject(:user) { build(:user, primaries: [primary]) }
 

--- a/spec/component/models/user_spec.rb
+++ b/spec/component/models/user_spec.rb
@@ -1709,19 +1709,16 @@ describe User, type: :model do
     end
   end
 
-  describe '#available_deputies' do
+  describe '#available_deputy?' do
     let(:user) { create(:user, primary_assignments: [available_assignment, unconfirmed_assignment, inactive_assignment]) }
     let(:available_assignment) { create(:deputy_assignment, :active) }
     let(:unconfirmed_assignment) { create(:deputy_assignment, :unconfirmed) }
     let(:inactive_assignment) { create(:deputy_assignment, :inactive) }
 
     it 'limits the available deputies to those that are active and confirmed' do
-      expect(user.deputies).to contain_exactly(
-        available_assignment.deputy,
-        unconfirmed_assignment.deputy,
-        inactive_assignment.deputy
-      )
-      expect(user.available_deputies).to contain_exactly(available_assignment.deputy)
+      expect(user).to be_available_deputy(available_assignment.deputy)
+      expect(user).not_to be_available_deputy(unconfirmed_assignment.deputy)
+      expect(user).not_to be_available_deputy(inactive_assignment.deputy)
     end
   end
 

--- a/spec/component/services/current_user_builder_spec.rb
+++ b/spec/component/services/current_user_builder_spec.rb
@@ -11,31 +11,83 @@ describe CurrentUserBuilder do
     let(:user) { nil }
 
     it { is_expected.to be_a(NullUser) }
+    its(:impersonator) { is_expected.to be_nil }
   end
 
-  context 'when the current user is not an admin' do
+  context 'when the current user is not an admin or a deputy' do
     let(:user) { build(:user, is_admin: false) }
 
     it { is_expected.to be_a(UserDecorator) }
     it { is_expected.not_to be_masquerading }
+    it { is_expected.to eq(user) }
+    its(:impersonator) { is_expected.to be_nil }
   end
 
-  context 'when the current user is an admin' do
+  context 'when the current user is an admin NOT posing as another user' do
     let(:user) { build(:user, is_admin: true) }
 
     it { is_expected.to be_a(UserDecorator) }
     it { is_expected.not_to be_masquerading }
+    it { is_expected.to eq(user) }
+    its(:impersonator) { is_expected.to be_nil }
   end
 
-  context 'when the current is an admin that is posing as another user' do
+  context 'when the current user is an admin that is posing as another user' do
     let(:user) { build(:user, is_admin: true) }
-    let(:session) { { pretend_user_id: 'user-to-pretend' } }
+    let(:primary_user) { build(:user) }
+    let(:session) { { MasqueradingBehaviors::SESSION_ID => 'primary-user-id' } }
 
     before do
-      allow(User).to receive(:find).with('user-to-pretend').and_return('mock user')
+      allow(User).to receive(:find).with('primary-user-id').and_return(primary_user)
     end
 
     it { is_expected.to be_a(UserDecorator) }
     it { is_expected.to be_masquerading }
+    it { is_expected.to eq(primary_user) }
+    its(:impersonator) { is_expected.to eq(user) }
+  end
+
+  context 'when the current user is a deputy posing as their primary' do
+    let(:user) { build(:user) }
+    let(:primary_user) { build(:user, deputies: [user]) }
+    let(:session) { { MasqueradingBehaviors::SESSION_ID => 'primary-user-id' } }
+
+    before do
+      allow(User).to receive(:find).with('primary-user-id').and_return(primary_user)
+    end
+
+    it { is_expected.to be_a(UserDecorator) }
+    it { is_expected.to be_masquerading }
+    it { is_expected.to eq(primary_user) }
+    its(:impersonator) { is_expected.to eq(user) }
+  end
+
+  context 'when the current user is no longer the deputy, but still has an active session id for the primary' do
+    let(:user) { build(:user) }
+    let(:primary_user) { build(:user) }
+    let(:session) { { MasqueradingBehaviors::SESSION_ID => 'primary-user-id' } }
+
+    before do
+      allow(User).to receive(:find).with('primary-user-id').and_return(primary_user)
+    end
+
+    it { is_expected.to be_a(UserDecorator) }
+    it { is_expected.not_to be_masquerading }
+    it { is_expected.to eq(user) }
+    its(:impersonator) { is_expected.to be_nil }
+  end
+
+  context 'when the primary user no longer exists, but the current user still has an active session id for them' do
+    let(:user) { build(:user) }
+    let(:session) { { MasqueradingBehaviors::SESSION_ID => 'primary-user-id' } }
+
+    before do
+      allow(User).to receive(:find).with('primary-user-id').and_return(nil)
+    end
+
+    it { is_expected.to be_a(UserDecorator) }
+    it { is_expected.not_to be_masquerading }
+    it { is_expected.to eq(user) }
+    its(:impersonator) { is_expected.to be_nil }
   end
 end

--- a/spec/component/services/current_user_builder_spec.rb
+++ b/spec/component/services/current_user_builder_spec.rb
@@ -54,6 +54,7 @@ describe CurrentUserBuilder do
 
     before do
       allow(User).to receive(:find).with('primary-user-id').and_return(primary_user)
+      allow(primary_user).to receive(:available_deputies).and_return([user])
     end
 
     it { is_expected.to be_a(UserDecorator) }
@@ -69,6 +70,7 @@ describe CurrentUserBuilder do
 
     before do
       allow(User).to receive(:find).with('primary-user-id').and_return(primary_user)
+      allow(primary_user).to receive(:available_deputies).and_return([])
     end
 
     it { is_expected.to be_a(UserDecorator) }

--- a/spec/component/services/current_user_builder_spec.rb
+++ b/spec/component/services/current_user_builder_spec.rb
@@ -54,7 +54,7 @@ describe CurrentUserBuilder do
 
     before do
       allow(User).to receive(:find).with('primary-user-id').and_return(primary_user)
-      allow(primary_user).to receive(:available_deputies).and_return([user])
+      allow(primary_user).to receive(:available_deputy?).and_return(true)
     end
 
     it { is_expected.to be_a(UserDecorator) }
@@ -70,7 +70,7 @@ describe CurrentUserBuilder do
 
     before do
       allow(User).to receive(:find).with('primary-user-id').and_return(primary_user)
-      allow(primary_user).to receive(:available_deputies).and_return([])
+      allow(primary_user).to receive(:available_deputy?).and_return(false)
     end
 
     it { is_expected.to be_a(UserDecorator) }

--- a/spec/integration/profiles/edit_spec.rb
+++ b/spec/integration/profiles/edit_spec.rb
@@ -92,6 +92,23 @@ describe 'editing profile preferences' do
           expect(page).to have_link('Stop being abc123')
         end
       end
+
+      context 'when logged in as a deputy of the user' do
+        let(:deputy) { create(:user) }
+
+        before do
+          create(:deputy_assignment, primary: user, deputy: deputy)
+          authenticate_as(deputy)
+          visit profile_path(webaccess_id: 'abc123')
+        end
+
+        it 'allows the deputy to become and unbecome the user in the profile' do
+          click_link('Become this user')
+          expect(page).to have_link('Unbecome this user')
+          click_link('Manage my profile')
+          expect(page).to have_link('Stop being abc123')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
When a primary user assigns another user as their deputy, they should be able to masquerade as that user and do things on their behalf. This feature already existed for admins, so we're expanding it to include users that are assigned deputy roles from another primary user.

To preserve the existing feature, the original admin functions are extracted to a shared module. The admin controller then only needs to include the core functions of that module. The user controller uses those same features but adds additional protections that ensure only the deputy may become the primary.

Once the deputy is vetted, they become the primary user via CurrentUserBuilder. However, certain circumstances may arise where the primary user removes their deputy, revoking their privileges, but that deputy may still have an active session. To guard against that, we always check the deputies privileges for _each request_. The downside of this is that we can't memoize current_user. CurrentUserBuilder is always called, even if the user it not intending to masquerade as another user.

Fixes #315 