### PR TITLE
Allow hosts for development and testing

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,6 +5,10 @@ require 'active_support/core_ext/integer/time'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Allow any hostnames used locally
+  config.hosts << 'localhost'
+  config.hosts << 'researcher-metadata.test' # for puma-dev
+
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,6 +10,9 @@ require 'active_support/core_ext/integer/time'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Disable hostname checks
+  config.hosts.clear
+
   config.cache_classes = false
   config.action_view.cache_template_loading = true
 


### PR DESCRIPTION
Allows any hostname that we might be using locally. This bypasses certain security measures than only need to be used in production. Hostname checks for test are disabled completely, allowing any named host. This is typically "www.example.com" by default, but it doesn't need to be tested.