### PR TITLE
Deputy assignment email templates

### DIFF
--- a/app/mailers/deputy_assignments_mailer.rb
+++ b/app/mailers/deputy_assignments_mailer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class DeputyAssignmentsMailer < ApplicationMailer
+  def deputy_assignment_confirmation(deputy_assignment)
+    @primary = deputy_assignment.primary
+    @deputy = deputy_assignment.deputy
+    @deputy_url = 'FIXME' # TODO: replace this with the actual URL
+    mail to: @primary.email,
+         subject: 'PSU Researcher Metadata Database - Proxy Request Confirmed',
+         from: 'openaccess@psu.edu',
+         reply_to: 'openaccess@psu.edu'
+  end
+
+  def deputy_assignment_declination(deputy_assignment)
+    @primary = deputy_assignment.primary
+    @deputy = deputy_assignment.deputy
+    mail to: @primary.email,
+         subject: 'PSU Researcher Metadata Database - Proxy Request Declined',
+         from: 'openaccess@psu.edu',
+         reply_to: 'openaccess@psu.edu'
+  end
+
+  def deputy_assignment_request(deputy_assignment)
+    @primary = deputy_assignment.primary
+    @deputy = deputy_assignment.deputy
+    @deputy_url = 'FIXME' # TODO: replace this with the actual URL
+    mail to: @deputy.email,
+         subject: 'PSU Researcher Metadata Database - Proxy Assignment Request',
+         from: 'openaccess@psu.edu',
+         reply_to: 'openaccess@psu.edu'
+  end
+end

--- a/app/views/deputy_assignments_mailer/_footer.html.erb
+++ b/app/views/deputy_assignments_mailer/_footer.html.erb
@@ -1,0 +1,9 @@
+<p>
+  With questions, contact <a href="mailto:openaccess@psu.edu">openaccess@psu.edu</a>.
+</p>
+
+<p>
+  Sincerely,
+  <br>
+  The Researcher Metadata Database Team
+</p>

--- a/app/views/deputy_assignments_mailer/deputy_assignment_confirmation.html.erb
+++ b/app/views/deputy_assignments_mailer/deputy_assignment_confirmation.html.erb
@@ -1,0 +1,13 @@
+<p>
+  Dear <%= @primary.name %>,
+</p>
+
+<p>
+  <%= @deputy.name %> (<%= @deputy.webaccess_id %>) has confirmed their status as a proxy acting on your behalf in the
+  Researcher Metadata Database. They can now do everything you can do in the Researcher Metadata Database, including
+  uploading an article to ScholarSphere, providing an article’s open access URL, waiving the Penn State open access
+  policy for an article, and choosing which articles to display in your public profile. You can remove their proxy
+  status at the following URL: <a href="<%= @deputy_url %>"><%= @deputy_url %></a>
+</p>
+
+<%= render :partial => 'footer' %>

--- a/app/views/deputy_assignments_mailer/deputy_assignment_declination.html.erb
+++ b/app/views/deputy_assignments_mailer/deputy_assignment_declination.html.erb
@@ -1,0 +1,10 @@
+<p>
+  Dear <%= @primary.name %>,
+</p>
+
+<p>
+  <%= @deputy.name %> (<%= @deputy.webaccess_id %>) has declined your request that they act as a proxy on your behalf
+  in the Researcher Metadata Database. If this was a mistake, you can try adding them again.
+</p>
+
+<%= render :partial => 'footer' %>

--- a/app/views/deputy_assignments_mailer/deputy_assignment_request.html.erb
+++ b/app/views/deputy_assignments_mailer/deputy_assignment_request.html.erb
@@ -1,0 +1,17 @@
+<p>
+  Dear <%= @deputy.name %>,
+</p>
+
+<p>
+  <%= @primary.name %> (<%= @primary.webaccess_id %>) has requested that you act as a proxy on their behalf in the
+  Researcher Metadata Database. This will enable you to do everything they can do in the Researcher Metadata Database,
+  including uploading an article to ScholarSphere, providing an article’s open access URL, waiving the Penn State open
+  access policy for an article, and choosing which articles to display in their public profile.
+</p>
+
+<p>
+  Please visit the following URL to confirm or decline your status as a proxy for <%= @primary.name %>:
+  <a href="<%= @deputy_url %>"><%= @deputy_url %></a>
+</p>
+
+<%= render :partial => 'footer' %>

--- a/lib/mailer_previews/deputy_assignments_mailer_preview.rb
+++ b/lib/mailer_previews/deputy_assignments_mailer_preview.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class DeputyAssignmentsMailerPreview < ActionMailer::Preview
+  # Accessible from http://localhost:3000/rails/mailers/deputy_assignments_mailer/deputy_assignment_request
+  def deputy_assignment_request
+    DeputyAssignmentsMailer.deputy_assignment_request(fake_deputy_assignment)
+  end
+
+  # Accessible from http://localhost:3000/rails/mailers/deputy_assignments_mailer/deputy_assignment_confirmation
+  def deputy_assignment_confirmation
+    DeputyAssignmentsMailer.deputy_assignment_confirmation(fake_deputy_assignment)
+  end
+
+  # Accessible from http://localhost:3000/rails/mailers/deputy_assignments_mailer/deputy_assignment_declination
+  def deputy_assignment_declination
+    DeputyAssignmentsMailer.deputy_assignment_declination(fake_deputy_assignment)
+  end
+
+  private
+
+    def fake_deputy_assignment
+      OpenStruct.new({
+                       primary: OpenStruct.new({ name: 'Primary Jones', webaccess_id: 'pj123' }),
+                       deputy: OpenStruct.new({ name: 'Deputy Smith', webaccess_id: 'ds456' })
+                     })
+    end
+end

--- a/spec/component/mailers/deputy_assignments_mailer_spec.rb
+++ b/spec/component/mailers/deputy_assignments_mailer_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+describe DeputyAssignmentsMailer, type: :model do
+  let(:primary) { double 'user',
+                         email: 'primary@psu.edu',
+                         name: 'Primary User',
+                         webaccess_id: 'abc123' }
+
+  let(:deputy) { double 'user',
+                        email: 'deputy@psu.edu',
+                        name: 'Deputy User',
+                        webaccess_id: 'def456' }
+
+  let(:deputy_assignment) { double 'deputy_assignment',
+                                   primary: primary,
+                                   deputy: deputy }
+
+  describe '#deputy_assignment_confirmation' do
+    subject(:email) { described_class.deputy_assignment_confirmation(deputy_assignment) }
+
+    it "sends the email to the given user's email address" do
+      expect(email.to).to eq ['primary@psu.edu']
+    end
+
+    it 'sends the email from the correct address' do
+      expect(email.from).to eq ['openaccess@psu.edu']
+    end
+
+    it 'sends the email with the correct subject' do
+      expect(email.subject).to eq 'PSU Researcher Metadata Database - Proxy Request Confirmed'
+    end
+
+    it 'sets the correct reply-to address' do
+      expect(email.reply_to).to eq ['openaccess@psu.edu']
+    end
+
+    describe 'the message body' do
+      let(:body) { email.body.raw_source }
+
+      it 'addresses the user by name' do
+        expect(body).to include('Dear Primary User,')
+      end
+
+      it 'mentions the deputy by name and webaccess ID' do
+        expect(body).to include('Deputy User (def456)')
+      end
+    end
+  end
+
+  describe '#deputy_assignment_declination' do
+    subject(:email) { described_class.deputy_assignment_declination(deputy_assignment) }
+
+    it "sends the email to the given user's email address" do
+      expect(email.to).to eq ['primary@psu.edu']
+    end
+
+    it 'sends the email from the correct address' do
+      expect(email.from).to eq ['openaccess@psu.edu']
+    end
+
+    it 'sends the email with the correct subject' do
+      expect(email.subject).to eq 'PSU Researcher Metadata Database - Proxy Request Declined'
+    end
+
+    it 'sets the correct reply-to address' do
+      expect(email.reply_to).to eq ['openaccess@psu.edu']
+    end
+
+    describe 'the message body' do
+      let(:body) { email.body.raw_source }
+
+      it 'addresses the user by name' do
+        expect(body).to include('Dear Primary User,')
+      end
+
+      it 'mentions the deputy by name and webaccess ID' do
+        expect(body).to include('Deputy User (def456)')
+      end
+    end
+  end
+
+  describe '#deputy_assignment_request' do
+    subject(:email) { described_class.deputy_assignment_request(deputy_assignment) }
+
+    before do
+      allow(ActionMailer::Base).to receive(:default_url_options).and_return({ host: 'example.com' })
+    end
+
+    it "sends the email to the given user's email address" do
+      expect(email.to).to eq ['deputy@psu.edu']
+    end
+
+    it 'sends the email from the correct address' do
+      expect(email.from).to eq ['openaccess@psu.edu']
+    end
+
+    it 'sends the email with the correct subject' do
+      expect(email.subject).to eq 'PSU Researcher Metadata Database - Proxy Assignment Request'
+    end
+
+    it 'sets the correct reply-to address' do
+      expect(email.reply_to).to eq ['openaccess@psu.edu']
+    end
+
+    describe 'the message body' do
+      let(:body) { email.body.raw_source }
+
+      it 'addresses the user by name' do
+        expect(body).to include('Dear Deputy User,')
+      end
+    end
+  end
+end


### PR DESCRIPTION
We now have 3 emails which will get sent out when a deputy assignment is requested, confirmed, or declined.

These email templates can be merged in, and then Ryan can use them when he is finished adding the deputy assignment request/confirm/decline functionality.