### PR TITLE
Rails Admin: remove JS to close side nav

### DIFF
--- a/app/assets/javascripts/rails_admin/custom/close-side-nav.js
+++ b/app/assets/javascripts/rails_admin/custom/close-side-nav.js
@@ -1,7 +1,0 @@
-$(document).on('ready pjax:end', function(event){
-    if ($(location).attr("href").match(/.*\/admin\/duplicate_publication_group/)) {
-        if ($('a.opened').length) {
-            toggleMenu(event)
-        }
-    }
-});


### PR DESCRIPTION
Since we upgraded to Rails Admin 2 and removed the Rails Admin Material Theme, the side nav can no longer open and close, so this code no longer does anything.