### PR TITLE
Allow users to claim publications

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -124,6 +124,7 @@ RSpec/ContextWording:
 RSpec/DescribeClass:
   Exclude:
     - 'spec/integration/notifications/open_access_reminder_spec.rb'
+    - 'spec/integration/profiles/claim_publication_spec.rb'
     - 'spec/integration/profiles/edit_spec.rb'
     - 'spec/integration/profiles/external_publication_waivers/create_spec.rb'
     - 'spec/integration/profiles/external_publication_waivers/new_spec.rb'

--- a/app/assets/stylesheets/manage_profile.scss
+++ b/app/assets/stylesheets/manage_profile.scss
@@ -68,6 +68,7 @@ body {
 // scss-lint:disable QualifyingElement
 table.legend {
   font-size: 13px;
+  margin: 10px 0;
 
   td {
     padding: 4px 8px;

--- a/app/controllers/authorships_controller.rb
+++ b/app/controllers/authorships_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AuthorshipsController < UserController
+  def create; end
+
   def update
     authorship = current_user.authorships.find(params[:id])
     authorship.update!(authorship_params.merge(updated_by_owner_at: Time.current))

--- a/app/controllers/authorships_controller.rb
+++ b/app/controllers/authorships_controller.rb
@@ -3,10 +3,12 @@
 class AuthorshipsController < UserController
   def create
     publication = Publication.find(authorship_create_params[:publication_id])
-    current_user.claim_publication(
+    service = AuthorshipClaimService.new(
+      current_user,
       publication,
       authorship_create_params[:author_number]
     )
+    service.create
 
     flash[:notice] = I18n.t('profile.authorships.create.success', title: publication.title)
     redirect_to edit_profile_publications_path

--- a/app/controllers/authorships_controller.rb
+++ b/app/controllers/authorships_controller.rb
@@ -1,11 +1,23 @@
 # frozen_string_literal: true
 
 class AuthorshipsController < UserController
-  def create; end
+  def create
+    publication = Publication.find(authorship_create_params[:publication_id])
+    current_user.claim_publication(
+      publication,
+      authorship_create_params[:author_number]
+    )
+
+    flash[:notice] = I18n.t('profile.authorships.create.success', title: publication.title)
+    redirect_to edit_profile_publications_path
+  rescue ActiveRecord::RecordInvalid => e
+    flash[:alert] = e.message
+    redirect_to publication_path(authorship_create_params[:publication_id])
+  end
 
   def update
     authorship = current_user.authorships.find(params[:id])
-    authorship.update!(authorship_params.merge(updated_by_owner_at: Time.current))
+    authorship.update!(authorship_update_params.merge(updated_by_owner_at: Time.current))
   end
 
   def sort
@@ -20,7 +32,11 @@ class AuthorshipsController < UserController
 
   private
 
-    def authorship_params
+    def authorship_create_params
+      params.require(:authorship).permit([:publication_id, :author_number])
+    end
+
+    def authorship_update_params
       params.require(:authorship).permit(:visible_in_profile)
     end
 end

--- a/app/controllers/internal_publication_waivers_controller.rb
+++ b/app/controllers/internal_publication_waivers_controller.rb
@@ -2,12 +2,12 @@
 
 class InternalPublicationWaiversController < OpenAccessWorkflowController
   def new
-    authorship = current_user.authorships.find_by!(publication_id: params[:id])
+    authorship = current_user.confirmed_authorships.find_by!(publication_id: params[:id])
     @waiver = InternalPublicationWaiver.new(authorship: authorship)
   end
 
   def create
-    authorship = current_user.authorships.find_by!(publication_id: params[:id])
+    authorship = current_user.confirmed_authorships.find_by!(publication_id: params[:id])
     waiver = InternalPublicationWaiver.new(waiver_params)
     waiver.authorship = authorship
     waiver.save!

--- a/app/controllers/open_access_workflow_controller.rb
+++ b/app/controllers/open_access_workflow_controller.rb
@@ -8,7 +8,7 @@ class OpenAccessWorkflowController < UserController
   private
 
     def publication
-      @publication ||= current_user.publications.journal_article.published.find(params[:id])
+      @publication ||= current_user.confirmed_publications.journal_article.published.find(params[:id])
     end
 
     def redirect_if_inaccessible

--- a/app/controllers/orcid_works_controller.rb
+++ b/app/controllers/orcid_works_controller.rb
@@ -2,7 +2,7 @@
 
 class OrcidWorksController < UserController
   def create
-    authorship = current_user.authorships.find(params[:authorship_id])
+    authorship = current_user.confirmed_authorships.find(params[:authorship_id])
 
     if authorship
       if authorship.orcid_resource_identifier.present?

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -5,7 +5,7 @@ class PublicationsController < ProfileManagementController
     if params[:search] && params[:search][:title].present?
       @publications = base_publication_query
         .where('title ILIKE ?', "%#{params[:search][:title]}%")
-        .limit(100).order(:title)
+        .limit(1000).order(:title)
     end
   end
 

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -3,23 +3,17 @@
 class PublicationsController < ProfileManagementController
   def index
     if params[:search] && params[:search][:title].present?
-      @publications = base_publication_query
+      @publications = Publication.claimable_by(current_user)
         .where('title ILIKE ?', "%#{params[:search][:title]}%")
         .limit(1000).order(:title)
     end
   end
 
   def show
-    @publication = base_publication_query.find(params[:id])
+    @publication = Publication.claimable_by(current_user).find(params[:id])
   end
 
   private
-
-    def base_publication_query
-      Publication
-        .visible
-        .where.not(id: current_user.authorships.map { |a| a.publication.id })
-    end
 
     def resolve_layout
       'manage_profile'

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class PublicationsController < ProfileManagementController
+  def index
+    if params[:search] && params[:search][:title].present?
+      @publications = Publication
+        .visible
+        .where.not(id: current_user.authorships.map { |a| a.publication.id })
+        .where('title ILIKE ?', "%#{params[:search][:title]}%")
+        .limit(100)
+    end
+  end
+end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -3,11 +3,25 @@
 class PublicationsController < ProfileManagementController
   def index
     if params[:search] && params[:search][:title].present?
-      @publications = Publication
-        .visible
-        .where.not(id: current_user.authorships.map { |a| a.publication.id })
+      @publications = base_publication_query
         .where('title ILIKE ?', "%#{params[:search][:title]}%")
-        .limit(100)
+        .limit(100).order(:title)
     end
   end
+
+  def show
+    @publication = base_publication_query.find(params[:id])
+  end
+
+  private
+
+    def base_publication_query
+      Publication
+        .visible
+        .where.not(id: current_user.authorships.map { |a| a.publication.id })
+    end
+
+    def resolve_layout
+      'manage_profile'
+    end
 end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -3,16 +3,16 @@
 class PublicationsController < ProfileManagementController
   def index
     publications = Publication.claimable_by(current_user)
-    if params[:search] && (title_search? || name_search?)
-      if title_search?
+    if search_present?
+      if title_search_present?
         publications = publications
-          .where('title ILIKE ?', "%#{params[:search][:title]}%")
+          .where('title ILIKE ?', "%#{title_param}%")
       end
-      if name_search?
+      if name_search_present?
         publications = publications
           .joins(:contributor_names)
-          .where('contributor_names.first_name ILIKE ?', "%#{params[:search][:first_name]}%")
-          .where('contributor_names.last_name ILIKE ?', "%#{params[:search][:last_name]}%")
+          .where('contributor_names.first_name ILIKE ?', "%#{first_name_param}%")
+          .where('contributor_names.last_name ILIKE ?', "%#{last_name_param}%")
       end
     else
       publications = Publication.none
@@ -24,17 +24,47 @@ class PublicationsController < ProfileManagementController
     @publication = Publication.claimable_by(current_user).find(params[:id])
   end
 
+  helper_method :search_present?, :search_incomplete?, :search_term
+
   private
 
     def resolve_layout
       'manage_profile'
     end
 
-    def title_search?
-      params[:search][:title].present?
+    def title_param
+      params[:search][:title]
     end
 
-    def name_search?
-      params[:search][:first_name].present? && params[:search][:last_name].present?
+    def first_name_param
+      params[:search][:first_name]
+    end
+
+    def last_name_param
+      params[:search][:last_name]
+    end
+
+    def title_search_present?
+      title_param.present?
+    end
+
+    def name_search_present?
+      first_name_param.present? && last_name_param.present?
+    end
+
+    def search_present?
+      params[:search] && (title_search_present? || name_search_present?)
+    end
+
+    def search_incomplete?
+      params[:search] && !(title_search_present? || name_search_present?)
+    end
+
+    def search_term
+      term = ''
+      term += %{title:  "#{title_param}"} if title_search_present?
+      term += ' and ' if title_search_present? && name_search_present?
+      term += %{author name:  "#{first_name_param} #{last_name_param}"} if name_search_present?
+      term
     end
 end

--- a/app/decorators/authorship_decorator.rb
+++ b/app/decorators/authorship_decorator.rb
@@ -30,6 +30,10 @@ class AuthorshipDecorator < BaseDecorator
     end
   end
 
+  def exportable_to_orcid?
+    !!user.orcid_access_token && publication.orcid_allowed? && confirmed
+  end
+
   private
 
     attr_reader :view_context
@@ -43,7 +47,7 @@ class AuthorshipDecorator < BaseDecorator
     end
 
     def profile_management_pub_title
-      if no_open_access_information? && is_journal_article? && published?
+      if no_open_access_information? && is_journal_article? && published? && confirmed
         view_context.link_to title, view_context.edit_open_access_publication_path(publication)
       else
         title

--- a/app/mailers/admin_notifications_mailer.rb
+++ b/app/mailers/admin_notifications_mailer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AdminNotificationsMailer < ApplicationMailer
+  def authorship_claim(authorship)
+    @authorship = authorship
+    mail to: 'L-FAMS@lists.psu.edu', # TODO: replace this with the real email address once it's known
+         subject: 'RMD Authorship Claim',
+         from: 'openaccess@psu.edu'
+  end
+end

--- a/app/mailers/admin_notifications_mailer.rb
+++ b/app/mailers/admin_notifications_mailer.rb
@@ -3,7 +3,7 @@
 class AdminNotificationsMailer < ApplicationMailer
   def authorship_claim(authorship)
     @authorship = authorship
-    mail to: 'L-FAMS@lists.psu.edu', # TODO: replace this with the real email address once it's known
+    mail to: 'rmd-admin@psu.edu',
          subject: 'RMD Authorship Claim',
          from: 'openaccess@psu.edu'
   end

--- a/app/models/authorship.rb
+++ b/app/models/authorship.rb
@@ -36,6 +36,7 @@ class Authorship < ApplicationRecord
 
   scope :unclaimable, -> { where('claimed_by_user IS TRUE OR confirmed IS TRUE') }
   scope :confirmed, -> { where(confirmed: true) }
+  scope :claimed_and_unconfirmed, -> { where(confirmed: false, claimed_by_user: true) }
 
   def description
     "##{id} (#{user.name} - #{publication.title})"
@@ -56,10 +57,21 @@ class Authorship < ApplicationRecord
   rails_admin do
     object_label_method { :description }
 
+    list do
+      scopes [nil, :claimed_and_unconfirmed]
+      field(:id)
+      field(:user)
+      field(:publication)
+      field(:confirmed)
+      field(:claimed_by_user)
+    end
+
     edit do
       field(:user) { read_only true }
       field(:publication) { read_only true }
-      field(:author_number) { read_only true }
+      field(:claimed_by_user) { read_only true }
+      field(:author_number)
+      field(:confirmed)
       field(:orcid_resource_identifier)
       field(:waiver)
     end

--- a/app/models/authorship.rb
+++ b/app/models/authorship.rb
@@ -32,7 +32,7 @@ class Authorship < ApplicationRecord
            :published?,
            to: :publication,
            prefix: false
-  delegate :webaccess_id, to: :user, prefix: true
+  delegate :webaccess_id, :name, to: :user, prefix: true
 
   scope :unclaimable, -> { where('claimed_by_user IS TRUE OR confirmed IS TRUE') }
   scope :confirmed, -> { where(confirmed: true) }

--- a/app/models/authorship.rb
+++ b/app/models/authorship.rb
@@ -34,6 +34,9 @@ class Authorship < ApplicationRecord
            prefix: false
   delegate :webaccess_id, to: :user, prefix: true
 
+  scope :unclaimable, -> { where('claimed_by_user IS TRUE OR confirmed IS TRUE') }
+  scope :confirmed, -> { where(confirmed: true) }
+
   def description
     "##{id} (#{user.name} - #{publication.title})"
   end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -80,7 +80,7 @@ class Publication < ApplicationRecord
         }
 
   scope :subject_to_open_access_policy, -> { journal_article.published.where('published_on >= ?', Publication::OPEN_ACCESS_POLICY_START) }
-  scope :claimable_by, ->(user) { visible.where.not(id: user.authorships.unclaimable.map { |a| a.publication.id }) }
+  scope :claimable_by, ->(user) { journal_article.visible.where.not(id: user.authorships.unclaimable.map { |a| a.publication.id }) }
 
   scope :open_access, -> { distinct(:id).left_outer_joins(:open_access_locations).where.not(open_access_locations: { publication_id: nil }) }
   scope :scholarsphere_open_access, -> { open_access.where(open_access_locations: { source: Source::SCHOLARSPHERE }) }

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -80,6 +80,7 @@ class Publication < ApplicationRecord
         }
 
   scope :subject_to_open_access_policy, -> { journal_article.published.where('published_on >= ?', Publication::OPEN_ACCESS_POLICY_START) }
+  scope :claimable_by, ->(user) { visible.where.not(id: user.authorships.unclaimable.map { |a| a.publication.id }) }
 
   scope :open_access, -> { distinct(:id).left_outer_joins(:open_access_locations).where.not(open_access_locations: { publication_id: nil }) }
   scope :scholarsphere_open_access, -> { open_access.where(open_access_locations: { source: Source::SCHOLARSPHERE }) }
@@ -117,7 +118,11 @@ class Publication < ApplicationRecord
   end
 
   def confirmed_authorships
-    authorships.where(confirmed: true)
+    authorships.confirmed
+  end
+
+  def confirmed_users
+    users.where(authorships: { confirmed: true })
   end
 
   def doi_url_path

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -80,7 +80,7 @@ class Publication < ApplicationRecord
         }
 
   scope :subject_to_open_access_policy, -> { journal_article.published.where('published_on >= ?', Publication::OPEN_ACCESS_POLICY_START) }
-  scope :claimable_by, ->(user) { journal_article.visible.where.not(id: user.authorships.unclaimable.map { |a| a.publication.id }) }
+  scope :claimable_by, ->(user) { journal_article.visible.where.not(id: user.authorships.unclaimable.map(&:publication_id)) }
 
   scope :open_access, -> { distinct(:id).left_outer_joins(:open_access_locations).where.not(open_access_locations: { publication_id: nil }) }
   scope :scholarsphere_open_access, -> { open_access.where(open_access_locations: { source: Source::SCHOLARSPHERE }) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -181,6 +181,10 @@ class User < ApplicationRecord
     publications.where(authorships: { confirmed: true })
   end
 
+  def confirmed_authorships
+    authorships.confirmed
+  end
+
   def admin?
     is_admin
   end
@@ -242,6 +246,19 @@ class User < ApplicationRecord
 
   def mark_as_updated_by_user
     self.updated_by_user_at = Time.current
+  end
+
+  def claim_publication(publication, author_number)
+    a = Authorship.find_or_initialize_by(
+      user: self,
+      publication: publication
+    )
+    unless a.persisted? && a.confirmed
+      a.author_number = author_number
+      a.confirmed = false
+      a.claimed_by_user = true
+    end
+    a.save!
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -259,6 +259,7 @@ class User < ApplicationRecord
       a.claimed_by_user = true
     end
     a.save!
+    a
   end
 
   private

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -44,13 +44,20 @@ class UserProfile
   end
 
   def publications
-    publication_records.where('authorships.visible_in_profile is true').map do |pub|
+    public_publication_records.where('authorships.visible_in_profile is true').map do |pub|
       AuthorshipDecorator.new(pub).label
     end
   end
 
-  def publication_records
+  def public_publication_records
     user_query.publications.journal_article.order('authorships.position_in_profile ASC NULLS FIRST, published_on DESC')
+  end
+
+  def publication_records
+    user_query
+      .publications(include_unconfirmed: true)
+      .where(%{(authorships.claimed_by_user IS TRUE AND authorships.confirmed IS FALSE) OR authorships.confirmed IS TRUE})
+      .journal_article.order('authorships.position_in_profile ASC NULLS FIRST, published_on DESC')
   end
 
   def grants

--- a/app/queries/api/v1/user_query.rb
+++ b/app/queries/api/v1/user_query.rb
@@ -28,14 +28,18 @@ module API::V1
       user.etds
     end
 
-    def publications(params = {})
+    def publications(params = { include_unconfirmed: false })
       if user.show_all_publications
+        data = if params[:include_unconfirmed] == true
+                 user.publications.visible
+               else
+                 user.confirmed_publications.visible
+               end
+
         if params[:start_year] && params[:end_year]
           starts_on = Date.new(params[:start_year].to_i)
           ends_on = Date.new(params[:end_year].to_i).end_of_year
-          data = user.publications.visible.where(published_on: starts_on..ends_on)
-        else
-          data = user.confirmed_publications.visible
+          data = data.where(published_on: starts_on..ends_on)
         end
 
         if params[:order_first_by].present?

--- a/app/services/authorship_claim_service.rb
+++ b/app/services/authorship_claim_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AuthorshipClaimService
+  def initialize(user, publication, author_number)
+    @user = user
+    @publication = publication
+    @author_number = author_number
+  end
+
+  def create
+    authorship = user.claim_publication(publication, author_number)
+    AdminNotificationsMailer.authorship_claim(authorship).deliver_now
+  end
+
+  private
+
+    attr_reader :user, :publication, :author_number
+end

--- a/app/views/admin_notifications_mailer/authorship_claim.html.erb
+++ b/app/views/admin_notifications_mailer/authorship_claim.html.erb
@@ -1,0 +1,8 @@
+<p>
+  <%= @authorship.user_name %> has claimed authorship of the publication <em><%= @authorship.title %></em>.
+</p>
+
+<p>
+  <%= link_to 'Click here', rails_admin.edit_url(model_name: :authorship, id: @authorship.id) %>
+  to review the authorship information and to confirm the authorship if it is correct.
+</p>

--- a/app/views/profiles/_orcid_export_button.html.erb
+++ b/app/views/profiles/_orcid_export_button.html.erb
@@ -1,4 +1,4 @@
-<% if a.user.orcid_access_token && a.publication.orcid_allowed? %>
+<% if a.exportable_to_orcid? %>
   <% if a.orcid_resource_identifier.present? %>
     <sup>*</sup>This information has been added to your ORCID record.
   <% else %>

--- a/app/views/profiles/edit_publications.html.erb
+++ b/app/views/profiles/edit_publications.html.erb
@@ -1,7 +1,8 @@
 <div class="manage-profile-list">
   <h4>Manage Profile Publications</h4>
   <div id="icon-key">
-    <h6>Icon key:</h6>
+    <h5>Icon key:</h5>
+    <h6>Open Access Status</h6>
     <table class="legend">
       <tr>
         <td><%= fa_icon('unlock-alt') %></td>
@@ -26,6 +27,17 @@
       <tr>
         <td><%= fa_icon('circle-o-notch') %></td>
         <td>This publication is in press and will not be subject to the open access policy until it is published.</td>
+      </tr>
+    </table>
+    <h6>Authorship Confirmation</h6>
+    <table class="legend">
+      <tr>
+        <td><%= fa_icon('check') %></td>
+        <td>Your authorship of the publication has been confirmed.</td>
+      </tr>
+      <tr>
+        <td><%= fa_icon('minus') %></td>
+        <td>Confirmation of your authorship of the publication is pending review by an RMD administrator.</td>
       </tr>
     </table>
   </div>

--- a/app/views/profiles/edit_publications.html.erb
+++ b/app/views/profiles/edit_publications.html.erb
@@ -43,6 +43,7 @@
       <th>Publication</th>
       <th>Visible in profile</th>
       <th>Open Access Status</th>
+      <th>Authorship Confirmed</th>
       <th></th>
     </tr>
     </thead>
@@ -58,6 +59,13 @@
           </td>
           <td class="oa-status">
             <%= fa_icon(a.open_access_status_icon) %>
+          </td>
+          <td>
+            <% if a.confirmed %>
+              <%= fa_icon('check') %>
+            <% else %>
+              <%= fa_icon('minus') %>
+            <% end %>
           </td>
           <td>
             <%= render partial: 'orcid_export_button', locals: { a: a } %>

--- a/app/views/profiles/edit_publications.html.erb
+++ b/app/views/profiles/edit_publications.html.erb
@@ -33,6 +33,9 @@
     If you need to waive open access obligations for a publication that is not in the list below, then please fill
     out this <%= link_to "waiver form", new_external_publication_waiver_path %>.
   </p>
+  <p>
+    Don't see one of your publications below? You can <%= link_to 'Search', publications_path %> the database and claim publications that we haven't been able to link to your profile.
+  </p>
   <table class="table">
     <thead>
     <tr>

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -2,7 +2,7 @@
     <h4>Search Publications</h4>
 
     <%= simple_form_for :search, url: publications_path, method: :get do |f| %>
-      <%= f.input :title, type: :text, label: 'Title', required: false %>
+      <%= f.input :title, as: :string, label: 'Title', required: false %>
       <%= f.submit 'Search', class: 'btn btn-primary' %>
     <% end %>
   </div>

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -17,8 +17,8 @@
       </thead>
       <tbody>
         <% @publications.each do |p| %>
-          <tr>
-            <td id="<%= dom_id(p) %>"><%= p.title %></td>
+          <tr id="<%= dom_id(p) %>">
+            <td><%= p.title %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -1,28 +1,36 @@
-  <div class="open-access-action">
-    <h4>Search Publications</h4>
+<div class="open-access-action">
+  <h4>Search Publications</h4>
 
-    <%= simple_form_for :search, url: publications_path, method: :get do |f| %>
+  <%= simple_form_for :search, url: publications_path, method: :get do |f| %>
+    <h6>By title:</h6>
+    <fieldset>
       <%= f.input :title, as: :string, label: 'Title', required: false %>
-      <%= f.submit 'Search', class: 'btn btn-primary' %>
-    <% end %>
-  </div>
-
-  <% if @publications %>
-    <h5>Matching Publications</h5>
-    <table class="table">
-      <thead>
-        <tr>
-          <th>Title</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @publications.each do |p| %>
-          <tr id="<%= dom_id(p) %>">
-            <td><%= p.title %></td>
-            <td><%= link_to 'View Details', publication_path(p) %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    </fieldset>
+    <h6>By author first and last name:</h6>
+    <fieldset>
+      <%= f.input :first_name, as: :string, label: 'First name', required: false %>
+      <%= f.input :last_name, as: :string, label: 'Last name', required: false %>
+    </fieldset>
+    <%= f.submit 'Search', class: 'btn btn-primary' %>
   <% end %>
+</div>
+
+<% if @publications.any? %>
+  <h5>Matching Publications</h5>
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @publications.each do |p| %>
+        <tr id="<%= dom_id(p) %>">
+          <td><%= p.title %></td>
+          <td><%= link_to 'View Details', publication_path(p) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -13,12 +13,14 @@
       <thead>
         <tr>
           <th>Title</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
         <% @publications.each do |p| %>
           <tr id="<%= dom_id(p) %>">
             <td><%= p.title %></td>
+            <td><%= link_to 'View Details', publication_path(p) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -16,7 +16,7 @@
 </div>
 
 <% if @publications.any? %>
-  <h5>Matching Publications</h5>
+  <h5>Matching publications for <%= search_term %></h5>
   <table class="table">
     <thead>
       <tr>
@@ -33,4 +33,8 @@
       <% end %>
     </tbody>
   </table>
+<% elsif search_present? %>
+  <p>No matching publications found for <%= search_term %>.</p>
+<% elsif search_incomplete? %>
+  <p>Please enter search terms either for the publication title or for an author's first and last name.</p>
 <% end %>

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -1,0 +1,26 @@
+  <div class="open-access-action">
+    <h4>Search Publications</h4>
+
+    <%= simple_form_for :search, url: publications_path, method: :get do |f| %>
+      <%= f.input :title, type: :text, label: 'Title', required: false %>
+      <%= f.submit 'Search', class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+
+  <% if @publications %>
+    <h5>Matching Publications</h5>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Title</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @publications.each do |p| %>
+          <tr>
+            <td id="<%= dom_id(p) %>"><%= p.title %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -8,7 +8,7 @@
       </tr>
       <tr>
         <td><strong>Penn State Authors:</strong></td>
-        <td><%= @publication.users.map { |u| u.name }.join(', ') %>
+        <td><%= @publication.confirmed_users.map { |u| u.name }.join(', ') %>
       </tr>
       <tr>
         <td><strong>DOI:</strong></td>
@@ -35,6 +35,10 @@
       </tr>
     </table>
   </div>
-  <%= button_to 'Claim Publication', authorships_path, class: 'btn btn-primary' %>
+  <%= simple_form_for :authorship, url: authorships_path do |f| %>
+    <%= f.input :publication_id, as: :hidden, input_html: { value: @publication.id } %>
+    <%= f.input :author_number, as: :integer, input_html: { min: 1 }, hint: 'A number indicating your position in the list of all of the authors of this publication - e.g. if you are first author, you would enter 1' %>
+    <%= f.submit 'Claim Publication', class: 'btn btn-primary' %>
+  <% end %>
 </div>
 <%= link_to 'Back to list', :back %>

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -1,0 +1,40 @@
+<h3>Publication Details</h3>
+<div class="open-access-action">
+  <div class="oa-publication-details">
+    <table>
+      <tr>
+        <td><strong>Title:</strong></td>
+        <td><%= @publication.title %></td>
+      </tr>
+      <tr>
+        <td><strong>Penn State Authors:</strong></td>
+        <td><%= @publication.users.map { |u| u.name }.join(', ')%>
+      </tr>
+      <tr>
+        <td><strong>DOI:</strong></td>
+        <td><%= @publication.doi %></td>
+      </tr>
+      <tr>
+        <td><strong>Journal:</strong></td>
+        <td><%= @publication.published_by %></td>
+      </tr>
+      <tr>
+        <td><strong>Volume:</strong></td>
+        <td><%= @publication.volume %></td>
+      </tr>
+      <tr>
+        <td><strong>Issue:</strong></td>
+        <td><%= @publication.issue %></td>
+      </tr>
+      <tr>
+        <td><strong>Pages:</strong></td>
+        <td><%= @publication.page_range %></td>
+      <tr>
+        <td><strong>Year Published:</strong></td>
+        <td><%= @publication.year %></td>
+      </tr>
+    </table>
+  </div>
+  <%= button_to 'Claim Publication', authorships_path, class: 'btn btn-primary' %>
+</div>
+<%= link_to 'Back to list', :back %>

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -8,7 +8,7 @@
       </tr>
       <tr>
         <td><strong>Penn State Authors:</strong></td>
-        <td><%= @publication.users.map { |u| u.name }.join(', ')%>
+        <td><%= @publication.users.map { |u| u.name }.join(', ') %>
       </tr>
       <tr>
         <td><strong>DOI:</strong></td>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -63,7 +63,8 @@ RailsAdmin.config do |config|
             :StatisticsSnapshot,
             :EmailError,
             :ScholarsphereWorkDeposit,
-            :ImporterErrorLog]
+            :ImporterErrorLog,
+            :Authorship]
     end
     new do
       only [:Publication,

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -97,7 +97,8 @@ RailsAdmin.config do |config|
             :ImporterErrorLog,
             :OpenAccessLocation,
             :Publication,
-            :User]
+            :User,
+            :Authorship]
     end
     index_publications_by_organization do
       only [:Publication]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,6 +140,9 @@ en:
         success: "The work record was successfully added to your ORCID record."
         account_not_linked: "Your ORCID record is no longer linked to your metadata profile."
         error: "There was an error adding your work history to your ORCID record."
+    authorships:
+      create:
+        success: "You have successfully claimed authorship of the publication \"%{title}\". Your claim will be reviewed by an administrator and will need to be approved before the publication will appear in your public profile."
   models:
     open_access_url_form:
       validation_errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
   get 'profile' => redirect('profile/publications/edit')
   scope 'profile' do
     get 'search_publications' => 'publications#index', as: :publications
+    get 'search_publications/:id' => 'publications#show', as: :publication
     get 'publications/edit' => 'profiles#edit_publications', as: :edit_profile_publications
     get 'presentations/edit' => 'profiles#edit_presentations', as: :edit_profile_presentations
     get 'performances/edit' => 'profiles#edit_performances', as: :edit_profile_performances
@@ -77,6 +78,7 @@ Rails.application.routes.draw do
   patch 'proxies/:id/confirm' => 'deputy_assignments#confirm', as: :confirm_deputy_assignment
   delete 'proxies/:id' => 'deputy_assignments#destroy', as: :deputy_assignment
 
+  post 'authorships' => 'authorships#create', as: :authorships
   put 'authorships/sort' => 'authorships#sort'
   put 'authorships/:id' => 'authorships#update', as: :authorship
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
 
   get 'profile' => redirect('profile/publications/edit')
   scope 'profile' do
+    get 'search_publications' => 'publications#index', as: :publications
     get 'publications/edit' => 'profiles#edit_publications', as: :edit_profile_publications
     get 'presentations/edit' => 'profiles#edit_presentations', as: :edit_profile_presentations
     get 'performances/edit' => 'profiles#edit_performances', as: :edit_profile_performances

--- a/db/migrate/20211105202204_add_claimed_by_user_column_to_authorships.rb
+++ b/db/migrate/20211105202204_add_claimed_by_user_column_to_authorships.rb
@@ -1,0 +1,5 @@
+class AddClaimedByUserColumnToAuthorships < ActiveRecord::Migration[5.2]
+  def change
+    add_column :authorships, :claimed_by_user, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_05_183946) do
+ActiveRecord::Schema.define(version: 2021_11_05_202204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2021_11_05_183946) do
     t.datetime "open_access_notification_sent_at"
     t.string "orcid_resource_identifier"
     t.datetime "updated_by_owner_at"
+    t.boolean "claimed_by_user", default: false
     t.index ["publication_id"], name: "index_authorships_on_publication_id"
     t.index ["user_id"], name: "index_authorships_on_user_id"
   end

--- a/lib/mailer_previews/admin_notifications_mailer_preview.rb
+++ b/lib/mailer_previews/admin_notifications_mailer_preview.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AdminNotificationsMailerPreview < ActionMailer::Preview
+  # Accessible from http://localhost:3000/rails/mailers/admin_notifications_mailer/authorship_claim
+  def authorship_claim
+    fake_auth = OpenStruct.new({ title: 'A Test Journal Article',
+                                 user_name: 'Example User',
+                                 id: 3 })
+
+    AdminNotificationsMailer.authorship_claim(fake_auth)
+  end
+end

--- a/spec/component/controllers/authorships_controller_spec.rb
+++ b/spec/component/controllers/authorships_controller_spec.rb
@@ -6,6 +6,12 @@ require 'component/controllers/shared_examples_for_an_unauthenticated_controller
 describe AuthorshipsController, type: :controller do
   it { is_expected.to be_a(UserController) }
 
+  describe '#create' do
+    let(:perform_request) { post :create }
+
+    it_behaves_like 'an unauthenticated controller'
+  end
+
   describe '#update' do
     let(:perform_request) { put :update, params: { id: 1 } }
 

--- a/spec/component/controllers/authorships_controller_spec.rb
+++ b/spec/component/controllers/authorships_controller_spec.rb
@@ -7,9 +7,56 @@ describe AuthorshipsController, type: :controller do
   it { is_expected.to be_a(UserController) }
 
   describe '#create' do
-    let(:perform_request) { post :create }
+    let(:perform_request) { post :create, params: { authorship: { publication_id: 3, author_number: 5 } } }
 
     it_behaves_like 'an unauthenticated controller'
+
+    context 'when authenticated' do
+      let!(:user) { create :user }
+      let(:pub) { double 'publication', id: 3, title: 'Test Title' }
+
+      before do
+        allow(request.env['warden']).to receive(:authenticate!).and_return(user)
+        allow(controller).to receive(:current_user).and_return(user)
+        allow(Publication).to receive(:find).with('3').and_return(pub)
+        allow(user).to receive(:claim_publication)
+      end
+
+      it 'claims the given publication for the current user' do
+        perform_request
+        expect(user).to have_received(:claim_publication).with(pub, '5')
+      end
+
+      it 'sets a success message' do
+        perform_request
+        expect(flash[:notice]).to eq I18n.t('profile.authorships.create.success', title: 'Test Title')
+      end
+
+      it "redirects to the list of publications for the user's profile" do
+        perform_request
+        expect(response).to redirect_to edit_profile_publications_path
+      end
+
+      context 'when a validation error occurs' do
+        let(:auth) { build :authorship }
+        let(:errors) { double 'validation errors', full_messages: ['bad data!'] }
+
+        before do
+          allow(auth).to receive(:errors).and_return errors
+          allow(user).to receive(:claim_publication).and_raise ActiveRecord::RecordInvalid.new(auth)
+        end
+
+        it 'sets an error message' do
+          perform_request
+          expect(flash[:alert]).to eq 'Validation failed: bad data!'
+        end
+
+        it 'redirects to the detail page for the given publication' do
+          perform_request
+          expect(response).to redirect_to publication_path(3)
+        end
+      end
+    end
   end
 
   describe '#update' do

--- a/spec/component/controllers/internal_publication_waivers_controller_spec.rb
+++ b/spec/component/controllers/internal_publication_waivers_controller_spec.rb
@@ -15,11 +15,11 @@ describe InternalPublicationWaiversController, type: :controller do
   let!(:auth) { create :authorship, user: user, publication: pub }
   let!(:waived_pub) { create :publication }
   let!(:other_waived_pub) { create :publication }
-  let!(:auth) { create :authorship, user: user, publication: pub }
   let!(:waived_auth) { create :authorship, user: user, publication: waived_pub }
   let!(:other_waived_auth) { create :authorship, user: other_user, publication: other_waived_pub }
   let!(:uploaded_auth) { create :authorship, user: user, publication: uploaded_pub }
   let!(:other_uploaded_auth) { create :authorship, user: other_user, publication: other_uploaded_pub }
+  let!(:unconfirmed_pub) { create :publication }
 
   before do
     create :authorship, user: user, publication: oa_pub
@@ -30,6 +30,10 @@ describe InternalPublicationWaiversController, type: :controller do
     create :authorship,
            user: user,
            publication: other_waived_pub
+    create :authorship,
+           user: user,
+           publication: unconfirmed_pub,
+           confirmed: false
 
     create :scholarsphere_work_deposit, authorship: uploaded_auth, status: 'Pending'
     create :scholarsphere_work_deposit, authorship: other_uploaded_auth, status: 'Pending'
@@ -54,6 +58,12 @@ describe InternalPublicationWaiversController, type: :controller do
       context 'when given the ID for a publication that does not belong to the user' do
         it 'returns 404' do
           expect { get :new, params: { id: other_pub.id } }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'when given the ID for a publication that belongs to the user but is unconfirmed' do
+        it 'returns 404' do
+          expect { get :new, params: { id: unconfirmed_pub.id } }.to raise_error ActiveRecord::RecordNotFound
         end
       end
 
@@ -122,6 +132,12 @@ describe InternalPublicationWaiversController, type: :controller do
       context 'when given the ID for a publication that does not belong to the user' do
         it 'returns 404' do
           expect { post :create, params: { id: other_pub.id } }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'when given the ID for a publication that belongs to the user but is unconfirmed' do
+        it 'returns 404' do
+          expect { post :create, params: { id: unconfirmed_pub.id } }.to raise_error ActiveRecord::RecordNotFound
         end
       end
 

--- a/spec/component/controllers/open_access_publications_controller_spec.rb
+++ b/spec/component/controllers/open_access_publications_controller_spec.rb
@@ -17,11 +17,11 @@ describe OpenAccessPublicationsController, type: :controller do
   let!(:auth) { create :authorship, user: user, publication: pub }
   let!(:waived_pub) { create :publication }
   let!(:other_waived_pub) { create :publication }
-  let!(:auth) { create :authorship, user: user, publication: pub }
   let!(:waived_auth) { create :authorship, user: user, publication: waived_pub }
   let!(:other_waived_auth) { create :authorship, user: other_user, publication: other_waived_pub }
   let!(:uploaded_auth) { create :authorship, user: user, publication: uploaded_pub }
   let!(:other_uploaded_auth) { create :authorship, user: other_user, publication: other_uploaded_pub }
+  let!(:unconfirmed_pub) { create :publication }
 
   before do
     create :authorship, user: user, publication: oa_pub
@@ -34,6 +34,10 @@ describe OpenAccessPublicationsController, type: :controller do
     create :authorship,
            user: user,
            publication: other_waived_pub
+    create :authorship,
+           user: user,
+           publication: unconfirmed_pub,
+           confirmed: false
 
     create :scholarsphere_work_deposit, authorship: uploaded_auth, status: 'Pending'
     create :scholarsphere_work_deposit, authorship: other_uploaded_auth, status: 'Pending'
@@ -64,6 +68,12 @@ describe OpenAccessPublicationsController, type: :controller do
       context 'when given the ID for a publication that is not published' do
         it 'returns 404' do
           expect { get :edit, params: { id: unpublished_pub.id } }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'when given the ID for a publication that belongs to the user but is unconfirmed' do
+        it 'returns 404' do
+          expect { get :edit, params: { id: unconfirmed_pub.id } }.to raise_error ActiveRecord::RecordNotFound
         end
       end
 
@@ -179,6 +189,12 @@ describe OpenAccessPublicationsController, type: :controller do
       context 'when given the ID for a publication that is not published' do
         it 'returns 404' do
           expect { patch :update, params: { id: unpublished_pub.id } }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'when given the ID for a publication that belongs to the user but is unconfirmed' do
+        it 'returns 404' do
+          expect { get :update, params: { id: unconfirmed_pub.id } }.to raise_error ActiveRecord::RecordNotFound
         end
       end
 
@@ -330,6 +346,12 @@ describe OpenAccessPublicationsController, type: :controller do
       context 'when given the ID for a publication that is not published' do
         it 'returns 404' do
           expect { post :create_scholarsphere_deposit, params: { id: unpublished_pub.id } }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'when given the ID for a publication that belongs to the user but is unconfirmed' do
+        it 'returns 404' do
+          expect { get :create_scholarsphere_deposit, params: { id: unconfirmed_pub.id } }.to raise_error ActiveRecord::RecordNotFound
         end
       end
 

--- a/spec/component/controllers/orcid_works_controller_spec.rb
+++ b/spec/component/controllers/orcid_works_controller_spec.rb
@@ -18,7 +18,7 @@ describe OrcidWorksController, type: :controller do
 
       before do
         allow(OrcidWork).to receive(:new).with(authorship).and_return(work)
-        allow(user).to receive_message_chain(:authorships, :find).and_return(authorship)
+        allow(user).to receive_message_chain(:confirmed_authorships, :find).and_return(authorship)
         allow(Time).to receive(:current).and_return(now)
         allow(request.env['warden']).to receive(:authenticate!).and_return(user)
         allow(controller).to receive(:current_user).and_return(user)

--- a/spec/component/controllers/publications_controller_spec.rb
+++ b/spec/component/controllers/publications_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+require 'component/controllers/shared_examples_for_an_unauthenticated_controller'
+
+describe PublicationsController, type: :controller do
+  it { is_expected.to be_a(UserController) }
+
+  describe '#index' do
+    let(:perform_request) { get :index }
+
+    it_behaves_like 'an unauthenticated controller'
+
+    context 'when the user is authenticated' do
+      let!(:user) { create :user }
+
+      before do
+        allow(request.env['warden']).to receive(:authenticate!).and_return(user)
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      it 'renders the publication list' do
+        expect(perform_request).to render_template(:index)
+      end
+    end
+  end
+end

--- a/spec/component/controllers/publications_controller_spec.rb
+++ b/spec/component/controllers/publications_controller_spec.rb
@@ -24,4 +24,24 @@ describe PublicationsController, type: :controller do
       end
     end
   end
+
+  describe '#show' do
+    let!(:pub) { create :publication }
+    let(:perform_request) { get :show, params: { id: pub.id } }
+
+    it_behaves_like 'an unauthenticated controller'
+
+    context 'when the user is authenticated' do
+      let!(:user) { create :user }
+
+      before do
+        allow(request.env['warden']).to receive(:authenticate!).and_return(user)
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      it 'renders the publication detail view' do
+        expect(perform_request).to render_template(:show)
+      end
+    end
+  end
 end

--- a/spec/component/mailers/admin_notifications_mailer_spec.rb
+++ b/spec/component/mailers/admin_notifications_mailer_spec.rb
@@ -16,7 +16,7 @@ describe AdminNotificationsMailer, type: :model do
     end
 
     it 'sends the email to the correct admin email address' do
-      expect(email.to).to eq ['L-FAMS@lists.psu.edu']
+      expect(email.to).to eq ['rmd-admin@psu.edu']
     end
 
     it 'sends the email from the correct address' do

--- a/spec/component/mailers/admin_notifications_mailer_spec.rb
+++ b/spec/component/mailers/admin_notifications_mailer_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+describe AdminNotificationsMailer, type: :model do
+  describe '#authorship_claim' do
+    subject(:email) { described_class.authorship_claim(auth) }
+
+    let(:auth) { double 'authorship',
+                        title: 'The Publication Title',
+                        user_name: 'Test User',
+                        id: 7 }
+
+    before do
+      allow(ActionMailer::Base).to receive(:default_url_options).and_return({ host: 'example.com' })
+    end
+
+    it 'sends the email to the correct admin email address' do
+      expect(email.to).to eq ['L-FAMS@lists.psu.edu']
+    end
+
+    it 'sends the email from the correct address' do
+      expect(email.from).to eq ['openaccess@psu.edu']
+    end
+
+    it 'sends the email with the correct subject' do
+      expect(email.subject).to eq 'RMD Authorship Claim'
+    end
+
+    describe 'the message body' do
+      let(:body) { email.body.raw_source }
+
+      it 'shows the name of the user who claimed the publication' do
+        expect(body).to match(auth.user_name)
+      end
+
+      it 'shows the title of the claimed publication' do
+        expect(body).to match(auth.title)
+      end
+
+      it 'shows a link to edit the authorship' do
+        expect(body).to match RailsAdmin.railtie_routes_url_helpers.edit_url(model_name: :authorship, id: 7, host: 'example.com')
+      end
+    end
+  end
+end

--- a/spec/component/models/authorship_spec.rb
+++ b/spec/component/models/authorship_spec.rb
@@ -88,6 +88,17 @@ describe Authorship, type: :model do
     end
   end
 
+  describe '.claimed_and_unconfirmed' do
+    let!(:auth1) { create :authorship, claimed_by_user: false, confirmed: false }
+    let!(:auth2) { create :authorship, claimed_by_user: true, confirmed: false }
+    let!(:auth3) { create :authorship, claimed_by_user: false, confirmed: true }
+    let!(:auth4) { create :authorship, claimed_by_user: true, confirmed: true }
+
+    it 'only returns authorships that are both claimed by a user and unconfirmed' do
+      expect(described_class.claimed_and_unconfirmed).to match_array [auth2]
+    end
+  end
+
   describe '#description' do
     let(:u) { create :user, first_name: 'Bob', last_name: 'Testerson' }
     let(:p) { create :publication, title: 'Example Pub' }

--- a/spec/component/models/authorship_spec.rb
+++ b/spec/component/models/authorship_spec.rb
@@ -65,6 +65,7 @@ describe Authorship, type: :model do
   it { is_expected.to delegate_method(:preferred_journal_title).to(:publication) }
   it { is_expected.to delegate_method(:published?).to(:publication) }
   it { is_expected.to delegate_method(:user_webaccess_id).to(:user).as(:webaccess_id) }
+  it { is_expected.to delegate_method(:user_name).to(:user).as(:name) }
 
   it { is_expected.to accept_nested_attributes_for(:waiver) }
 

--- a/spec/component/models/authorship_spec.rb
+++ b/spec/component/models/authorship_spec.rb
@@ -18,6 +18,7 @@ describe 'the authorships table', type: :model do
   it { is_expected.to have_db_column(:open_access_notification_sent_at).of_type(:datetime) }
   it { is_expected.to have_db_column(:orcid_resource_identifier).of_type(:string) }
   it { is_expected.to have_db_column(:updated_by_owner_at).of_type(:datetime) }
+  it { is_expected.to have_db_column(:claimed_by_user).of_type(:boolean).with_options(default: false) }
 
   it { is_expected.to have_db_index :user_id }
   it { is_expected.to have_db_index :publication_id }
@@ -66,6 +67,26 @@ describe Authorship, type: :model do
   it { is_expected.to delegate_method(:user_webaccess_id).to(:user).as(:webaccess_id) }
 
   it { is_expected.to accept_nested_attributes_for(:waiver) }
+
+  describe '.unclaimable' do
+    let!(:auth1) { create :authorship, claimed_by_user: false, confirmed: false }
+    let!(:auth2) { create :authorship, claimed_by_user: true, confirmed: false }
+    let!(:auth3) { create :authorship, claimed_by_user: false, confirmed: true }
+    let!(:auth4) { create :authorship, claimed_by_user: true, confirmed: true }
+
+    it 'only returns authorships that are either confirmed or already claimed by a user' do
+      expect(described_class.unclaimable).to match_array [auth2, auth3, auth4]
+    end
+  end
+
+  describe '.confirmed' do
+    let!(:auth1) { create :authorship, confirmed: false }
+    let!(:auth2) { create :authorship, confirmed: true }
+
+    it 'only returns authorships that are confirmed' do
+      expect(described_class.confirmed).to eq [auth2]
+    end
+  end
 
   describe '#description' do
     let(:u) { create :user, first_name: 'Bob', last_name: 'Testerson' }

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -325,6 +325,7 @@ describe Publication, type: :model do
     let!(:pub3) { create :publication, visible: true }
     let!(:pub4) { create :publication, visible: true }
     let!(:pub5) { create :publication, visible: true }
+    let!(:pub6) { create :publication, visible: true, publication_type: 'Book' }
 
     before do
       create :authorship, user: user, publication: pub3, confirmed: false, claimed_by_user: true

--- a/spec/component/models/user_profile_spec.rb
+++ b/spec/component/models/user_profile_spec.rb
@@ -109,6 +109,10 @@ describe UserProfile do
                                        visible: true }
     let!(:pub7) { create :publication, title: 'Unconfirmed Publication',
                                        visible: true }
+    let!(:pub8) { create :publication,
+                         title: 'Non-Journal-Article Publication',
+                         visible: true,
+                         publication_type: 'Book' }
     let(:pos1) { nil }
     let(:pos2) { nil }
     let(:pos3) { nil }
@@ -124,6 +128,7 @@ describe UserProfile do
       create :authorship, user: user, publication: pub5, position_in_profile: pos5
       create :authorship, user: user, publication: pub6, position_in_profile: pos6, visible_in_profile: false
       create :authorship, user: user, publication: pub7, confirmed: false
+      create :authorship, user: user, publication: pub8
 
       create :authorship, user: other_user, publication: pub1
     end
@@ -207,8 +212,95 @@ describe UserProfile do
                          title: 'Invisible Publication',
                          visible: false }
     let!(:pub6) { create :publication,
+                         title: 'Unconfirmed, Claimed Publication',
+                         visible: true,
+                         published_on: Date.new(2000, 1, 1) }
+    let!(:pub7) { create :publication,
+                         title: 'Non-Journal-Article Publication',
+                         visible: true,
+                         publication_type: 'Book' }
+    let!(:pub8) { create :publication,
+                         title: 'Unconfirmed, Unclaimed Publication',
+                         visible: true }
+    let(:pos1) { nil }
+    let(:pos2) { nil }
+    let(:pos3) { nil }
+    let(:pos4) { nil }
+    let(:pos5) { nil }
+    let(:pos6) { nil }
+
+    before do
+      create :authorship, user: user2, publication: pub1
+      create :authorship, user: user, publication: pub1, position_in_profile: pos1
+      create :authorship, user: user, publication: pub2, position_in_profile: pos2
+      create :authorship, user: user, publication: pub3, position_in_profile: pos3
+      create :authorship, user: user, publication: pub4, position_in_profile: pos4
+      create :authorship, user: user, publication: pub5, position_in_profile: pos5
+      create :authorship,
+             user: user,
+             publication: pub6,
+             position_in_profile: pos6,
+             confirmed: false,
+             claimed_by_user: true
+      create :authorship, user: user, publication: pub7
+      create :authorship, user: user, publication: pub8, confirmed: false, claimed_by_user: false
+    end
+
+    context "when none of the user's authorships have a profile position" do
+      it "returns the given user's publications in order by date" do
+        expect(profile.publication_records).to eq [pub4, pub3, pub2, pub1, pub6]
+      end
+    end
+
+    context "when one of the user's authorships has a profile position set" do
+      let(:pos2) { 1 }
+
+      it "returns the given user's publications in order first by position, then by date" do
+        expect(profile.publication_records).to eq [pub4, pub3, pub1, pub6, pub2]
+      end
+    end
+
+    context "when all of the user's authorships have profile positions set" do
+      let(:pos1) { 5 }
+      let(:pos2) { 3 }
+      let(:pos3) { 2 }
+      let(:pos4) { 6 }
+      let(:pos5) { 4 }
+      let(:pos6) { 1 }
+
+      it "returns the given user's publications in order by position" do
+        expect(profile.publication_records).to eq [pub6, pub3, pub2, pub1, pub4]
+      end
+    end
+  end
+
+  describe '#public_publication_records' do
+    let!(:user2) { create :user }
+    let!(:pub1) { create :publication,
+                         title: 'First Publication',
+                         visible: true,
+                         published_on: Date.new(2010, 1, 1) }
+    let!(:pub2) { create :publication,
+                         title: 'Second Publication',
+                         visible: true,
+                         published_on: Date.new(2015, 1, 1) }
+    let!(:pub3) { create :publication,
+                         title: 'Third Publication',
+                         visible: true,
+                         published_on: Date.new(2018, 1, 1) }
+    let!(:pub4) { create :publication,
+                         title: 'Undated Publication',
+                         visible: true }
+    let!(:pub5) { create :publication,
+                         title: 'Invisible Publication',
+                         visible: false }
+    let!(:pub6) { create :publication,
                          title: 'Unconfirmed Publication',
                          visible: true }
+    let!(:pub7) { create :publication,
+                         title: 'Non-Journal-Article Publication',
+                         visible: true,
+                         publication_type: 'Book' }
     let(:pos1) { nil }
     let(:pos2) { nil }
     let(:pos3) { nil }
@@ -223,19 +315,20 @@ describe UserProfile do
       create :authorship, user: user, publication: pub4, position_in_profile: pos4
       create :authorship, user: user, publication: pub5, position_in_profile: pos5
       create :authorship, user: user, publication: pub6, confirmed: false
+      create :authorship, user: user, publication: pub7
     end
 
     context "when none of the user's authorships have a profile position" do
-      it "returns an array of strings describing the given user's publications in order by date" do
-        expect(profile.publication_records).to eq [pub4, pub3, pub2, pub1]
+      it "returns the given user's publications in order by date" do
+        expect(profile.public_publication_records).to eq [pub4, pub3, pub2, pub1]
       end
     end
 
     context "when one of the user's authorships has a profile position set" do
       let(:pos2) { 1 }
 
-      it "returns an array of strings describing the given user's publications in order first by position, then by date" do
-        expect(profile.publication_records).to eq [pub4, pub3, pub1, pub2]
+      it "returns the given user's publications in order first by position, then by date" do
+        expect(profile.public_publication_records).to eq [pub4, pub3, pub1, pub2]
       end
     end
 
@@ -246,8 +339,8 @@ describe UserProfile do
       let(:pos4) { 6 }
       let(:pos5) { 4 }
 
-      it "returns an array of strings describing the given user's publications in order by position" do
-        expect(profile.publication_records).to eq [pub3, pub2, pub1, pub4]
+      it "returns the given user's publications in order by position" do
+        expect(profile.public_publication_records).to eq [pub3, pub2, pub1, pub4]
       end
     end
   end

--- a/spec/component/models/user_spec.rb
+++ b/spec/component/models/user_spec.rb
@@ -1774,6 +1774,13 @@ describe User, type: :model do
         expect(a.confirmed).to eq false
         expect(a.claimed_by_user).to eq true
       end
+
+      it 'returns the new authorship' do
+        a = user.claim_publication(pub, 3)
+        expect(a).to be_a Authorship
+        expect(a.user).to eq user
+        expect(a.publication).to eq pub
+      end
     end
 
     context 'when the user already has an authorship for the given publication' do
@@ -1799,6 +1806,13 @@ describe User, type: :model do
           expect(a.confirmed).to eq true
           expect(a.claimed_by_user).to eq false
         end
+
+        it 'returns the authorship' do
+          a = user.claim_publication(pub, 3)
+          expect(a).to be_a Authorship
+          expect(a.user).to eq user
+          expect(a.publication).to eq pub
+        end
       end
 
       context 'when the authorship is not confirmed' do
@@ -1815,6 +1829,13 @@ describe User, type: :model do
           expect(a.author_number).to eq 3
           expect(a.confirmed).to eq false
           expect(a.claimed_by_user).to eq true
+        end
+
+        it 'returns the authorship' do
+          a = user.claim_publication(pub, 3)
+          expect(a).to be_a Authorship
+          expect(a.user).to eq user
+          expect(a.publication).to eq pub
         end
       end
     end

--- a/spec/component/models/user_spec.rb
+++ b/spec/component/models/user_spec.rb
@@ -1022,6 +1022,20 @@ describe User, type: :model do
     end
   end
 
+  describe '#confirmed_authorships' do
+    let(:u1) { create :user }
+    let(:u2) { create :user }
+
+    let!(:auth1) { create :authorship, user: u1, confirmed: false }
+    let!(:auth2) { create :authorship, user: u1, confirmed: true }
+    let!(:auth3) { create :authorship, user: u2, confirmed: true }
+
+    it 'returns only confirmed authorships that belong to the user' do
+      expect(u1.confirmed_authorships).to eq [auth2]
+      expect(u1.confirmed_authorships.length).to eq 1
+    end
+  end
+
   describe '#admin?' do
     context "when the user's is_admin value is true" do
       before { user.is_admin = true }
@@ -1739,6 +1753,69 @@ describe User, type: :model do
         expect(user).to be_persisted
         expect(primary).not_to be_persisted
         expect(user.reload.primaries).to be_empty
+      end
+    end
+  end
+
+  describe '#claim_publication' do
+    let!(:pub) { create :publication }
+    let!(:user) { create :user }
+
+    context "when the user doesn't have an authorship for the given publication" do
+      it 'creates a new authorship' do
+        expect { user.claim_publication(pub, 3) }.to change { user.authorships.count }.by 1
+      end
+
+      it 'saves the correct data in the new authorship' do
+        user.claim_publication(pub, 3)
+
+        a = Authorship.find_by(user: user, publication: pub)
+        expect(a.author_number).to eq 3
+        expect(a.confirmed).to eq false
+        expect(a.claimed_by_user).to eq true
+      end
+    end
+
+    context 'when the user already has an authorship for the given publication' do
+      let!(:auth) { create :authorship,
+                           user: user,
+                           publication: pub,
+                           confirmed: confirmed,
+                           claimed_by_user: false,
+                           author_number: 2 }
+
+      context 'when the authorship is already confirmed' do
+        let(:confirmed) { true }
+
+        it 'does not create a new authorship' do
+          expect { user.claim_publication(pub, 3) }.not_to change(Authorship, :count)
+        end
+
+        it 'does not update the existing authorship' do
+          user.claim_publication(pub, 3)
+
+          a = Authorship.find_by(user: user, publication: pub)
+          expect(a.author_number).to eq 2
+          expect(a.confirmed).to eq true
+          expect(a.claimed_by_user).to eq false
+        end
+      end
+
+      context 'when the authorship is not confirmed' do
+        let(:confirmed) { false }
+
+        it 'does not create a new authorship' do
+          expect { user.claim_publication(pub, 3) }.not_to change(Authorship, :count)
+        end
+
+        it 'updates the authorship with the correct data' do
+          user.claim_publication(pub, 3)
+
+          a = Authorship.find_by(user: user, publication: pub)
+          expect(a.author_number).to eq 3
+          expect(a.confirmed).to eq false
+          expect(a.claimed_by_user).to eq true
+        end
       end
     end
   end

--- a/spec/component/queries/api/v1/user_query_spec.rb
+++ b/spec/component/queries/api/v1/user_query_spec.rb
@@ -107,6 +107,12 @@ describe API::V1::UserQuery do
         it "returns the user's visible, confirmed publications" do
           expect(uq.publications({})).to eq [vis_conf_pub]
         end
+
+        context 'when given params with a flag to include unconfirmed publications' do
+          it "returns all of the user's visible publications" do
+            expect(uq.publications({ include_unconfirmed: true })).to match_array [vis_conf_pub, vis_unconf_pub]
+          end
+        end
       end
     end
 

--- a/spec/component/services/authorship_claim_service_spec.rb
+++ b/spec/component/services/authorship_claim_service_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+describe AuthorshipClaimService do
+  let(:service) { described_class.new(user, pub, 3) }
+  let(:user) { double 'user', claim_publication: auth }
+  let(:pub) { double 'publication' }
+  let(:email) { spy 'notification email' }
+  let(:auth) { double 'authorship' }
+
+  before { allow(AdminNotificationsMailer).to receive(:authorship_claim).with(auth).and_return email }
+
+  describe '#create' do
+    it 'claims the given publication for the given user' do
+      service.create
+      expect(user).to have_received(:claim_publication).with(pub, 3)
+    end
+
+    it 'sends a notification email RMD admins' do
+      service.create
+      expect(email).to have_received(:deliver_now)
+    end
+  end
+end

--- a/spec/integration/admin/authorships/delete_spec.rb
+++ b/spec/integration/admin/authorships/delete_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+require 'integration/admin/shared_examples_for_admin_page'
+
+describe 'Deleting an Authorship', type: :feature do
+  let!(:auth) { create :authorship }
+
+  context 'when the current user is an admin' do
+    before do
+      authenticate_admin_user
+      visit rails_admin.delete_path(model_name: :authorship, id: auth.id)
+    end
+
+    describe 'visiting the form to delete an authorship' do
+      it_behaves_like 'a page with the admin layout'
+      it 'show the correct content' do
+        expect(page).to have_content 'Are you sure you want to delete this authorship'
+      end
+    end
+
+    describe 'submitting the form to delete an authorship' do
+      before do
+        click_button "Yes, I'm sure"
+      end
+
+      it 'deletes the authorship' do
+        expect { auth.reload }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it 'redirects to the authorship list' do
+        expect(page).to have_current_path rails_admin.index_path(model_name: :authorship), ignore_query: true
+      end
+    end
+  end
+
+  context 'when the current user is not an admin' do
+    before { authenticate_user }
+
+    it 'redirects back to the home page with an error message' do
+      visit rails_admin.delete_path(model_name: :authorship, id: auth.id)
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content I18n.t('admin.authorization.not_authorized')
+    end
+  end
+end

--- a/spec/integration/admin/authorships/edit_spec.rb
+++ b/spec/integration/admin/authorships/edit_spec.rb
@@ -4,17 +4,21 @@ require 'integration/integration_spec_helper'
 require 'integration/admin/shared_examples_for_admin_page'
 
 describe 'Admin authorship edit page', type: :feature do
-  let!(:user) { create(:user,
-                       first_name: 'Bob',
-                       last_name: 'Testuser') }
+  let!(:user) do
+    create(:user,
+           first_name: 'Bob',
+           last_name: 'Testuser')
+  end
 
   let!(:pub) { create :publication, title: 'A Test Publication' }
 
-  let!(:auth) { create :authorship,
-                       publication: pub,
-                       user: user,
-                       author_number: 5,
-                       orcid_resource_identifier: 'identifier-12345' }
+  let!(:auth) do
+    create :authorship,
+           publication: pub,
+           user: user,
+           author_number: 5,
+           orcid_resource_identifier: 'identifier-12345'
+  end
 
   context 'when the current user is an admin' do
     before { authenticate_admin_user }
@@ -34,12 +38,16 @@ describe 'Admin authorship edit page', type: :feature do
         expect(page).to have_link 'Bob Testuser', href: rails_admin.show_path(model_name: :user, id: user.id)
       end
 
-      it "shows the authorship's author number" do
-        expect(page).to have_content '5'
+      it "allows the authorship's author number to be edited" do
+        expect(page.find_field('Author number').value).to eq '5'
       end
 
       it "allows the authorship's ORCID resource identifier to be edited" do
         expect(page.find_field('Orcid resource identifier').value).to eq 'identifier-12345'
+      end
+
+      it "allows the authorship's confirmation flag to be set" do
+        expect(page.find_field('Confirmed').value).to eq '1'
       end
     end
 

--- a/spec/integration/admin/authorships/index_spec.rb
+++ b/spec/integration/admin/authorships/index_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+require 'integration/admin/shared_examples_for_admin_page'
+
+describe 'Admin authorships list', type: :feature do
+  context 'when the current user is an admin' do
+    before { authenticate_admin_user }
+
+    describe 'the page content' do
+      let(:pub1) { create(:publication, title: 'First Publication') }
+      let(:pub2) { create(:publication, title: 'Second Publication') }
+      let(:user1) { create(:user, first_name: 'Susan', last_name: 'Tester') }
+      let(:user2) { create(:user, first_name: 'Bob', last_name: 'User') }
+      let!(:auth1) { create(:authorship, user: user1, publication: pub1) }
+      let!(:auth2) { create(:authorship, user: user2, publication: pub2) }
+
+      before { visit rails_admin.index_path(model_name: :authorship) }
+
+      it 'shows the authorship list heading' do
+        expect(page).to have_content 'List of Authorships'
+      end
+
+      it 'shows information about each authorship' do
+        expect(page).to have_content auth1.id
+        expect(page).to have_link 'First Publication', href: rails_admin.show_path(model_name: :publication, id: pub1.id)
+        expect(page).to have_link 'Susan Tester', href: rails_admin.show_path(model_name: :user, id: user1.id)
+
+        expect(page).to have_content auth2.id
+        expect(page).to have_link 'Second Publication', href: rails_admin.show_path(model_name: :publication, id: pub2.id)
+        expect(page).to have_link 'Bob User', href: rails_admin.show_path(model_name: :user, id: user2.id)
+      end
+
+      it 'shows a link to show all authorships' do
+        expect(page).to have_link 'All'
+      end
+
+      it 'shows a link to show only authorships that are claimed and unconfirmed' do
+        expect(page).to have_link 'Claimed And Unconfirmed'
+      end
+    end
+
+    describe 'the page layout' do
+      before { visit rails_admin.index_path(model_name: :authorship) }
+
+      it_behaves_like 'a page with the admin layout'
+    end
+  end
+
+  context 'when the current user is not an admin' do
+    before { authenticate_user }
+
+    it 'redirects back to the home page with an error message' do
+      visit rails_admin.index_path(model_name: :authorship)
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content I18n.t('admin.authorization.not_authorized')
+    end
+  end
+end

--- a/spec/integration/admin/authorships/show_spec.rb
+++ b/spec/integration/admin/authorships/show_spec.rb
@@ -4,16 +4,20 @@ require 'integration/integration_spec_helper'
 require 'integration/admin/shared_examples_for_admin_page'
 
 describe 'Admin authorship detail page', type: :feature do
-  let!(:user) { create(:user,
-                       first_name: 'Bob',
-                       last_name: 'Testuser') }
+  let!(:user) do
+    create(:user,
+           first_name: 'Bob',
+           last_name: 'Testuser')
+  end
 
   let!(:pub) { create :publication, title: 'A Test Publication' }
 
-  let!(:auth) { create :authorship,
-                       publication: pub,
-                       user: user,
-                       author_number: 5 }
+  let!(:auth) do
+    create :authorship,
+           publication: pub,
+           user: user,
+           author_number: 5
+  end
 
   let!(:dep) { create :scholarsphere_work_deposit, title: 'Test Deposit', authorship: auth }
 

--- a/spec/integration/admin/authorships/update_spec.rb
+++ b/spec/integration/admin/authorships/update_spec.rb
@@ -4,17 +4,22 @@ require 'integration/integration_spec_helper'
 require 'integration/admin/shared_examples_for_admin_page'
 
 describe 'updating an authorship via the admin interface', type: :feature do
-  let!(:user) { create(:user,
-                       first_name: 'Bob',
-                       last_name: 'Testuser') }
+  let!(:user) do
+    create(:user,
+           first_name: 'Bob',
+           last_name: 'Testuser')
+  end
 
   let!(:pub) { create :publication, title: 'Test Publication' }
 
-  let!(:auth) { create :authorship,
-                       publication: pub,
-                       user: user,
-                       author_number: 5,
-                       orcid_resource_identifier: nil }
+  let!(:auth) do
+    create :authorship,
+           publication: pub,
+           user: user,
+           author_number: 5,
+           orcid_resource_identifier: nil,
+           confirmed: false
+  end
 
   context 'when the current user is an admin' do
     before do
@@ -25,11 +30,16 @@ describe 'updating an authorship via the admin interface', type: :feature do
     describe 'submitting the form with new data to update an authorship record' do
       before do
         fill_in 'Orcid resource identifier', with: 'Test Orcid Resource Identifier'
+        fill_in 'Author number', with: 2
+        check 'Confirmed'
         click_on 'Save'
       end
 
       it "updates the authorship's data" do
-        expect(auth.reload.orcid_resource_identifier).to eq 'Test Orcid Resource Identifier'
+        reloaded_auth = auth.reload
+        expect(reloaded_auth.orcid_resource_identifier).to eq 'Test Orcid Resource Identifier'
+        expect(reloaded_auth.author_number).to eq 2
+        expect(reloaded_auth.confirmed).to eq true
       end
     end
   end

--- a/spec/integration/admin/shared_examples_for_admin_page.rb
+++ b/spec/integration/admin/shared_examples_for_admin_page.rb
@@ -91,6 +91,12 @@ shared_examples_for 'a page with the admin layout' do
     end
   end
 
+  it 'shows a link to the Authorships index' do
+    within '.sidebar-nav' do
+      expect(page).to have_link 'Authorships'
+    end
+  end
+
   it 'shows a link to the admin dashboard' do
     expect(page).to have_link 'Dashboard'
   end

--- a/spec/integration/profiles/claim_publication_spec.rb
+++ b/spec/integration/profiles/claim_publication_spec.rb
@@ -4,7 +4,7 @@ require 'integration/integration_spec_helper'
 require 'integration/profiles/shared_examples_for_profile_management_page'
 
 describe 'claiming authorship of a publication' do
-  let(:user) { create :user, webaccess_id: 'abc123' }
+  let(:user) { create :user, webaccess_id: 'abc123', first_name: 'Test', last_name: 'Claimer' }
   let!(:pub1) { create :publication, title: 'Researcher Metadata Database Test Publication' }
   let(:pub2) { create :publication,
                       title: 'Another Researcher Metadata Database Test Publication',
@@ -105,6 +105,11 @@ describe 'claiming authorship of a publication' do
           before do
             fill_in 'Author number', with: 2
             click_button 'Claim Publication'
+          end
+
+          it 'sends a notification of the claim to the RMD admins' do
+            open_email('L-FAMS@lists.psu.edu')
+            expect(current_email.body).to match(/Test Claimer/)
           end
 
           it 'returns the user to page for managing their profile publications' do

--- a/spec/integration/profiles/claim_publication_spec.rb
+++ b/spec/integration/profiles/claim_publication_spec.rb
@@ -48,6 +48,10 @@ describe 'claiming authorship of a publication' do
           expect(page).not_to have_content pub3.title
         end
 
+        it 'shows the term used in the search' do
+          expect(page).to have_content 'metadata database'
+        end
+
         context 'when matching publications are not visible' do
           let!(:pub1) { create :publication, title: 'Researcher Metadata Database Test Publication', visible: false }
           let!(:pub2) { create :publication, title: 'Another Researcher Metadata Database Test Publication', visible: false }
@@ -56,6 +60,10 @@ describe 'claiming authorship of a publication' do
 
           it 'does not show the matching publications' do
             expect(page).not_to have_content 'Researcher Metadata Database Test Publication'
+          end
+
+          it 'shows the term used in the search' do
+            expect(page).to have_content 'metadata database'
           end
         end
 
@@ -67,6 +75,14 @@ describe 'claiming authorship of a publication' do
 
           it 'does not show the matching publications' do
             expect(page).not_to have_content 'Researcher Metadata Database Test Publication'
+          end
+
+          it 'shows the term used in the search' do
+            expect(page).to have_content 'metadata database'
+          end
+
+          it 'shows a helpful message' do
+            expect(page).to have_content 'No matching publications found'
           end
         end
 
@@ -80,6 +96,14 @@ describe 'claiming authorship of a publication' do
           it 'does not show the matching publications' do
             expect(page).not_to have_content 'Researcher Metadata Database Test Publication'
           end
+
+          it 'shows the term used in the search' do
+            expect(page).to have_content 'metadata database'
+          end
+
+          it 'shows a helpful message' do
+            expect(page).to have_content 'No matching publications found'
+          end
         end
       end
 
@@ -87,13 +111,17 @@ describe 'claiming authorship of a publication' do
         before { do_name_search }
 
         it 'shows a list of matching publications' do
-          expect(page).to have_content 'Matching Publications'
+          expect(page).to have_content 'Matching publications'
           within "#publication_#{pub1.id}" do
             expect(page).to have_content 'Researcher Metadata Database Test Publication'
           end
 
           expect(page).not_to have_content 'Another Researcher Metadata Database Test Publication'
           expect(page).not_to have_content pub3.title
+        end
+
+        it 'shows the term used in the search' do
+          expect(page).to have_content 's scientist'
         end
       end
 
@@ -107,6 +135,10 @@ describe 'claiming authorship of a publication' do
           expect(page).not_to have_content 'Test Publication'
           expect(page).not_to have_content pub3.title
           expect(page).not_to have_content 'Matching Publications'
+        end
+
+        it 'shows a helpful message' do
+          expect(page).to have_content 'Please enter search terms'
         end
       end
 

--- a/spec/integration/profiles/claim_publication_spec.rb
+++ b/spec/integration/profiles/claim_publication_spec.rb
@@ -108,7 +108,7 @@ describe 'claiming authorship of a publication' do
           end
 
           it 'sends a notification of the claim to the RMD admins' do
-            open_email('L-FAMS@lists.psu.edu')
+            open_email('rmd-admin@psu.edu')
             expect(current_email.body).to match(/Test Claimer/)
           end
 

--- a/spec/integration/profiles/claim_publication_spec.rb
+++ b/spec/integration/profiles/claim_publication_spec.rb
@@ -99,10 +99,38 @@ describe 'claiming authorship of a publication' do
           expect(page).to have_link 'Back to list'
         end
 
-        describe 'clicking the button to claim the publication' do
-          before { click_button 'Claim Publication' }
+        describe 'submitting the form to claim the publication' do
+          let(:new_authorship) { user.authorships.first }
 
-          it "doesn't blow up" do
+          before do
+            fill_in 'Author number', with: 2
+            click_button 'Claim Publication'
+          end
+
+          it 'returns the user to page for managing their profile publications' do
+            expect(page).to have_current_path edit_profile_publications_path, ignore_query: true
+          end
+
+          it 'shows the claimed publication in the list' do
+            within "#authorship_row_#{new_authorship.id}" do
+              expect(page).to have_content 'Another Researcher Metadata Database Test Publication'
+            end
+          end
+
+          it 'indicates that the authorship for the claimed publication is unconfirmed' do
+            within "#authorship_row_#{new_authorship.id}" do
+              expect(page).to have_css '.fa-minus'
+            end
+          end
+
+          it "does not show a button to add the claimed publication to the user's ORCiD record" do
+            within "#authorship_row_#{new_authorship.id}" do
+              expect(page).not_to have_css '.orcid-button'
+            end
+          end
+
+          it 'does not show a link to edit open access information for the claimed publication' do
+            expect(page).not_to have_link 'Another Researcher Metadata Database Test Publication'
           end
         end
       end

--- a/spec/integration/profiles/claim_publication_spec.rb
+++ b/spec/integration/profiles/claim_publication_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+require 'integration/profiles/shared_examples_for_profile_management_page'
+
+describe 'claiming authorship of a publication' do
+  let(:user) { create :user, webaccess_id: 'abc123' }
+  let!(:pub1) { create :publication, title: 'Researcher Metadata Database Test Publication' }
+  let!(:pub2) { create :publication, title: 'Another Researcher Metadata Database Test Publication' }
+
+  context 'when the user is signed in' do
+    before { authenticate_as(user) }
+
+    describe 'visiting the page to search for publications' do
+      before { visit publications_path }
+
+      it_behaves_like 'a profile management page'
+
+      describe 'submitting the form to search for publications by title' do
+        before { do_title_search }
+
+        it 'shows a list of matching publications' do
+          within "#publication_#{pub1.id}" do
+            expect(page).to have_content 'Researcher Metadata Database Test Publication'
+          end
+
+          within "#publication_#{pub2.id}" do
+            expect(page).to have_content 'Another Researcher Metadata Database Test Publication'
+          end
+        end
+
+        context 'when matching publications are not visible' do
+          let!(:pub1) { create :publication, title: 'Researcher Metadata Database Test Publication', visible: false }
+          let!(:pub2) { create :publication, title: 'Another Researcher Metadata Database Test Publication', visible: false }
+
+          before { do_title_search }
+
+          it 'does not show the matching publications' do
+            expect(page).not_to have_content 'Researcher Metadata Database Test Publication'
+          end
+        end
+
+        context 'when the user is already a known author of matching publications' do
+          before do
+            create :authorship, publication: pub1, user: user
+            create :authorship, publication: pub2, user: user
+            do_title_search
+          end
+
+          it 'does not show the matching publications' do
+            expect(page).not_to have_content 'Researcher Metadata Database Test Publication'
+          end
+        end
+      end
+    end
+  end
+end
+
+def do_title_search
+  visit publications_path
+  fill_in 'Title', with: 'Researcher Metadata Database Test Publication'
+  click_on 'Search'
+end

--- a/spec/integration/profiles/edit_spec.rb
+++ b/spec/integration/profiles/edit_spec.rb
@@ -213,6 +213,10 @@ describe 'editing profile preferences' do
         expect(page).to have_content 'Manage Profile Publications'
       end
 
+      it 'shows a link to search for publications' do
+        expect(page).to have_link 'Search', href: publications_path
+      end
+
       context 'when the user has publications' do
         let!(:pub_1) { create :publication,
                               title: "Bob's Publication",


### PR DESCRIPTION
This has the bulk of the functionality for https://github.com/psu-stewardship/researcher-metadata/issues/316, but at this point it only allows searching by publication title, and it doesn't yet send an email notification to an admin when a user claims a publication. The implementation differs slightly from what's described in the issue, but it should be equivalent.
