### PR TITLE
More transactional emails for proxy events

### DIFF
--- a/app/mailers/deputy_assignments_mailer.rb
+++ b/app/mailers/deputy_assignments_mailer.rb
@@ -29,4 +29,22 @@ class DeputyAssignmentsMailer < ApplicationMailer
          from: 'openaccess@psu.edu',
          reply_to: 'openaccess@psu.edu'
   end
+
+  def deputy_status_ended(deputy_assignment)
+    @primary = deputy_assignment.primary
+    @deputy = deputy_assignment.deputy
+    mail to: @primary.email,
+         subject: 'PSU Researcher Metadata Database - Proxy Status Ended',
+         from: 'openaccess@psu.edu',
+         reply_to: 'openaccess@psu.edu'
+  end
+
+  def deputy_status_revoked(deputy_assignment)
+    @primary = deputy_assignment.primary
+    @deputy = deputy_assignment.deputy
+    mail to: @deputy.email,
+         subject: 'PSU Researcher Metadata Database - Proxy Status Revoked',
+         from: 'openaccess@psu.edu',
+         reply_to: 'openaccess@psu.edu'
+  end
 end

--- a/app/views/deputy_assignments_mailer/deputy_status_ended.html.erb
+++ b/app/views/deputy_assignments_mailer/deputy_status_ended.html.erb
@@ -1,0 +1,11 @@
+<p>
+  Dear <%= @primary.name %>,
+</p>
+
+<p>
+  <%= @deputy.name %> (<%= @deputy.webaccess_id %>) has ended their status as a proxy acting on your behalf in the
+  Researcher Metadata Database. They can no longer act on your behalf. If this was a mistake, you can try adding them
+  as a proxy again.
+</p>
+
+<%= render :partial => 'footer' %>

--- a/app/views/deputy_assignments_mailer/deputy_status_revoked.html.erb
+++ b/app/views/deputy_assignments_mailer/deputy_status_revoked.html.erb
@@ -1,0 +1,11 @@
+<p>
+  Dear <%= @deputy.name %>,
+</p>
+
+<p>
+  <%= @primary.name %> (<%= @primary.webaccess_id %>) has revoked your status as a proxy acting on their behalf in the
+  Researcher Metadata Database. You can no longer act on their behalf. If this was a mistake, they can add you as a
+  proxy again.
+</p>
+
+<%= render :partial => 'footer' %>

--- a/lib/mailer_previews/deputy_assignments_mailer_preview.rb
+++ b/lib/mailer_previews/deputy_assignments_mailer_preview.rb
@@ -16,6 +16,16 @@ class DeputyAssignmentsMailerPreview < ActionMailer::Preview
     DeputyAssignmentsMailer.deputy_assignment_declination(fake_deputy_assignment)
   end
 
+  # Accessible from http://localhost:3000/rails/mailers/deputy_assignments_mailer/deputy_status_ended
+  def deputy_status_ended
+    DeputyAssignmentsMailer.deputy_status_ended(fake_deputy_assignment)
+  end
+
+  # Accessible from http://localhost:3000/rails/mailers/deputy_assignments_mailer/deputy_status_revoked
+  def deputy_status_revoked
+    DeputyAssignmentsMailer.deputy_status_revoked(fake_deputy_assignment)
+  end
+
   private
 
     def fake_deputy_assignment

--- a/spec/component/mailers/deputy_assignments_mailer_spec.rb
+++ b/spec/component/mailers/deputy_assignments_mailer_spec.rb
@@ -20,7 +20,7 @@ describe DeputyAssignmentsMailer, type: :model do
   describe '#deputy_assignment_confirmation' do
     subject(:email) { described_class.deputy_assignment_confirmation(deputy_assignment) }
 
-    it "sends the email to the given user's email address" do
+    it "sends the email to the primary user's email address" do
       expect(email.to).to eq ['primary@psu.edu']
     end
 
@@ -52,7 +52,7 @@ describe DeputyAssignmentsMailer, type: :model do
   describe '#deputy_assignment_declination' do
     subject(:email) { described_class.deputy_assignment_declination(deputy_assignment) }
 
-    it "sends the email to the given user's email address" do
+    it "sends the email to the primary user's email address" do
       expect(email.to).to eq ['primary@psu.edu']
     end
 
@@ -88,7 +88,7 @@ describe DeputyAssignmentsMailer, type: :model do
       allow(ActionMailer::Base).to receive(:default_url_options).and_return({ host: 'example.com' })
     end
 
-    it "sends the email to the given user's email address" do
+    it "sends the email to the deputy user's email address" do
       expect(email.to).to eq ['deputy@psu.edu']
     end
 
@@ -109,6 +109,70 @@ describe DeputyAssignmentsMailer, type: :model do
 
       it 'addresses the user by name' do
         expect(body).to include('Dear Deputy User,')
+      end
+    end
+  end
+
+  describe '#deputy_status_ended' do
+    subject(:email) { described_class.deputy_status_ended(deputy_assignment) }
+
+    it "sends the email to the primary user's email address" do
+      expect(email.to).to eq ['primary@psu.edu']
+    end
+
+    it 'sends the email from the correct address' do
+      expect(email.from).to eq ['openaccess@psu.edu']
+    end
+
+    it 'sends the email with the correct subject' do
+      expect(email.subject).to eq 'PSU Researcher Metadata Database - Proxy Status Ended'
+    end
+
+    it 'sets the correct reply-to address' do
+      expect(email.reply_to).to eq ['openaccess@psu.edu']
+    end
+
+    describe 'the message body' do
+      let(:body) { email.body.raw_source }
+
+      it 'addresses the user by name' do
+        expect(body).to include('Dear Primary User,')
+      end
+
+      it 'mentions the deputy by name and webaccess ID' do
+        expect(body).to include('Deputy User (def456)')
+      end
+    end
+  end
+
+  describe '#deputy_status_revoked' do
+    subject(:email) { described_class.deputy_status_revoked(deputy_assignment) }
+
+    it "sends the email to the deputy user's email address" do
+      expect(email.to).to eq ['deputy@psu.edu']
+    end
+
+    it 'sends the email from the correct address' do
+      expect(email.from).to eq ['openaccess@psu.edu']
+    end
+
+    it 'sends the email with the correct subject' do
+      expect(email.subject).to eq 'PSU Researcher Metadata Database - Proxy Status Revoked'
+    end
+
+    it 'sets the correct reply-to address' do
+      expect(email.reply_to).to eq ['openaccess@psu.edu']
+    end
+
+    describe 'the message body' do
+      let(:body) { email.body.raw_source }
+
+      it 'addresses the user by name' do
+        expect(body).to include('Dear Deputy User,')
+      end
+
+      it 'mentions the primary user by name and webaccess ID' do
+        expect(body).to include('Primary User (abc123)')
       end
     end
   end


### PR DESCRIPTION
Closes #367.

- an email is sent to the proxy when the primary user revokes their proxy status
- an email is sent to the primary user when the proxy ends their proxy status

Note that these are not yet hooked up to events. That will come later.