### PR TITLE
Profile: remove grid-margin-x class from footer

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -233,7 +233,7 @@
 </div>
 
 <footer>
-  <div class="grid-x grid-margin-x">
+  <div class="grid-x">
     <nav class="cell">
       <ul class="menu social align-center">
       </ul>


### PR DESCRIPTION
This class was adding unnecessary horizontal margins to the footer, causing a horizontal scrollbar to appear on the profile page.

### Before
<img width="1244" alt="Screen Shot 2021-11-15 at 11 22 33 AM" src="https://user-images.githubusercontent.com/639920/141817873-fb2dea32-f609-442b-97c5-8237f772fc6f.png">

### After
<img width="1244" alt="Screen Shot 2021-11-15 at 11 22 19 AM" src="https://user-images.githubusercontent.com/639920/141817897-a8fa4074-8044-43ec-9989-fcfe860fb42a.png">
