### PR TITLE
Unify UI of gray title bar for public/manage profile pages

### DIFF
--- a/app/assets/javascripts/profile/profile_page.js
+++ b/app/assets/javascripts/profile/profile_page.js
@@ -43,19 +43,4 @@ $(document).on('ready', function() {
   $(window).scroll(function() {
     stickyNav();
   });
-
-// Move upper nav to hamburger container
-  var moveNav = function(){
-    if (Foundation.MediaQuery.atLeast('large')) {
-      $('#upper-nav').appendTo("#upper-nav-wrapper");
-    } else {
-      $('#upper-nav').appendTo("#lower-nav");
-    }
-  };
-
-  moveNav();
-
-  $(window).resize(function() {
-    moveNav();
-  });
 });

--- a/app/assets/stylesheets/manage_profile.scss
+++ b/app/assets/stylesheets/manage_profile.scss
@@ -16,7 +16,7 @@ body {
   padding: 0 16px 0 0;
 
   .navbar-brand {
-    margin: 0 60px 0 8px;
+    margin: 8px 60px 0 8px;
     padding-top: 0;
   }
 }
@@ -30,29 +30,6 @@ body {
   .navbar-info {
     margin: 0 60px 0 8px;
     padding-top: 0;
-  }
-}
-
-.manage-profile-header {
-  background-color: #595959;
-  height: 38px;
-
-  h1 {
-    float: left;
-    padding: 8px 16px 0 6px;
-  }
-
-  ul {
-    float: right;
-    list-style: none;
-    padding: 6px 16px 0 0;
-  }
-
-  a,
-  h1 {
-    color: #fff;
-    font-size: 17px;
-    text-decoration: none;
   }
 }
 

--- a/app/assets/stylesheets/profile/screen.scss.erb
+++ b/app/assets/stylesheets/profile/screen.scss.erb
@@ -1,5 +1,4 @@
 /*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
-@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,700");
 
 html {
   line-height: 1.15;
@@ -4332,62 +4331,6 @@ table.hover:not(.unstriped) tr:nth-of-type(even):hover {
   display: none
 }
 
-.menu-icon {
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  width: 20px;
-  height: 16px;
-  cursor: pointer
-}
-
-.menu-icon::after {
-  position: absolute;
-  top: 0;
-  left: 0;
-  display: block;
-  width: 100%;
-  height: 2px;
-  background: #0a0a0a;
-  -webkit-box-shadow: 0 7px 0 #0a0a0a, 0 14px 0 #0a0a0a;
-  box-shadow: 0 7px 0 #0a0a0a, 0 14px 0 #0a0a0a;
-  content: ''
-}
-
-.menu-icon:hover::after {
-  background: #595959;
-  -webkit-box-shadow: 0 7px 0 #595959, 0 14px 0 #595959;
-  box-shadow: 0 7px 0 #595959, 0 14px 0 #595959
-}
-
-.menu-icon.dark {
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  width: 20px;
-  height: 16px;
-  cursor: pointer
-}
-
-.menu-icon.dark::after {
-  position: absolute;
-  top: 0;
-  left: 0;
-  display: block;
-  width: 100%;
-  height: 2px;
-  background: #0a0a0a;
-  -webkit-box-shadow: 0 7px 0 #0a0a0a, 0 14px 0 #0a0a0a;
-  box-shadow: 0 7px 0 #0a0a0a, 0 14px 0 #0a0a0a;
-  content: ''
-}
-
-.menu-icon.dark:hover::after {
-  background: #595959;
-  -webkit-box-shadow: 0 7px 0 #595959, 0 14px 0 #595959;
-  box-shadow: 0 7px 0 #595959, 0 14px 0 #595959
-}
-
 .title-bar {
   padding: .5rem;
   background: #fff;
@@ -4401,11 +4344,6 @@ table.hover:not(.unstriped) tr:nth-of-type(even):hover {
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center
-}
-
-.title-bar .menu-icon {
-  margin-left: .25rem;
-  margin-right: .25rem
 }
 
 .title-bar-left, .title-bar-right {
@@ -5785,7 +5723,7 @@ ol.list-upper-roman {
   }
 }
 
-.no-js #upper-nav, .no-js #lower-nav, .no-js #upper-nav-wrapper {
+.no-js #upper-nav, .no-js #lower-nav {
   display: none
 }
 
@@ -5903,8 +5841,6 @@ footer .links a {
   color: #fff;
   text-decoration: underline
 }
-
-
 
 .publication-title {
   font-weight: bold;

--- a/app/assets/stylesheets/profile/shared.scss
+++ b/app/assets/stylesheets/profile/shared.scss
@@ -1,3 +1,33 @@
+$gray: #595959;
+$white: #fff;
+
 .logo {
   max-width: 193px;
+}
+
+.profile-header {
+  background-color: $gray;
+  height: 38px;
+
+  h1 {
+    float: left;
+    padding: 8px 16px 0 6px;
+  }
+
+  ul {
+    float: right;
+    line-height: 1.5;
+    list-style: none;
+    margin-bottom: 0;
+    padding: 6px 16px 0 0;
+  }
+
+  a,
+  h1 {
+    color: $white;
+    font-size: 17px;
+    font-weight: normal;
+    line-height: 1.2;
+    text-decoration: none;
+  }
 }

--- a/app/views/layouts/manage_profile.html.erb
+++ b/app/views/layouts/manage_profile.html.erb
@@ -12,7 +12,7 @@
 </head>
 
 <body>
-  <nav class='manage-profile-header'>
+  <nav class="profile-header">
     <h1>Researcher Metadata Database</h1>
     <ul>
       <li><a href="https://libraries.psu.edu/" target="_blank">University Libraries</a></li>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,22 +1,16 @@
-<div class="title-bar" data-responsive-toggle="lower-nav" data-hide-for="large">
-  <a href="#"><%= image_tag('logo.png', alt: "Penn State") %></a>
-  <div class="title-bar-right">
-    <button class="menu-icon" type="button" data-toggle="lower-nav"></button>
-  </div>
-</div>
-<nav id="upper-nav-wrapper">
-  <ul class="menu vertical large-horizontal align-right" id="upper-nav">
+<nav class="profile-header">
+  <ul>
     <li><a href="https://libraries.psu.edu/" target="_blank">University Libraries</a></li>
   </ul>
+  <div class="clearfix"></div>
 </nav>
+<div class="title-bar" data-responsive-toggle="lower-nav" data-hide-for="large">
+  <a href="#"><%= image_tag('logo.png', alt: "Penn State") %></a>
+</div>
 <div class="top-bar" id="lower-nav">
   <div class="top-bar-left show-for-large">
     <a href="#"><%= image_tag('logo.png', alt: "Penn State", class: 'logo') %></a>
   </div>
-  <nav class="top-bar-right">
-    <ul class="menu vertical large-horizontal">
-    </ul>
-  </nav>
 </div>
 
 <div id="profile">


### PR DESCRIPTION
We've removed some unnecessary CSS and JS since we are no longer dynamically hiding/showing this bar on the public profile page.

We are now using the same shared CSS to render the gray bar the exact same way on both the public and manage profile pages.

We also stopped importing Open Sans on the public profile page for a few reasons:
- it was causing the font to render slightly differently on the public profile page than on other pages in the app
- we were not importing Open Sans on any other pages in the app (even though we are using Open Sans as a potential font on those other pages)
- removing the import of Open Sans could (slightly) speed up public profile load time

### Public Profile (large)
<img width="1184" alt="Screen Shot 2021-11-16 at 12 05 07 PM" src="https://user-images.githubusercontent.com/639920/142031652-fef9bf38-3b20-4f65-b598-1f0656a85091.png">

### Public Profile (small)
<img width="651" alt="Screen Shot 2021-11-16 at 12 05 13 PM" src="https://user-images.githubusercontent.com/639920/142031665-bd29b6b9-d7f6-4521-ad22-cd5392af94ef.png">

### Manage Profile
<img width="1346" alt="Screen Shot 2021-11-16 at 12 05 34 PM" src="https://user-images.githubusercontent.com/639920/142031680-37af0ec5-c719-4073-9aab-afeb41cd54e4.png">