### PR TITLE
332 delegate confirmation

### DIFF
--- a/app/controllers/deputy_assignments_controller.rb
+++ b/app/controllers/deputy_assignments_controller.rb
@@ -12,6 +12,10 @@ class DeputyAssignmentsController < ProfileManagementController
       deputy_webaccess_id: params.dig(:new_deputy_assignment_form, :deputy_webaccess_id)
     )
     if @new_deputy_assigment.save
+      DeputyAssignmentsMailer
+        .deputy_assignment_request(@new_deputy_assigment.deputy_assignment)
+        .deliver_now
+
       redirect_to deputy_assignments_path, notice: t('.success')
     else
       load_index_assignments
@@ -22,6 +26,9 @@ class DeputyAssignmentsController < ProfileManagementController
   def confirm
     @deputy_assignment = current_user.deputy_assignments.active.find(params[:id])
     @deputy_assignment.confirm!
+    DeputyAssignmentsMailer
+      .deputy_assignment_confirmation(@deputy_assignment)
+      .deliver_now
     flash.notice = t('.success', name: @deputy_assignment.primary.name)
   rescue ActiveRecord::RecordInvalid
     flash.alert = t('.error')
@@ -34,7 +41,12 @@ class DeputyAssignmentsController < ProfileManagementController
       .or(DeputyAssignment.where(deputy: current_user))
       .find(params[:id])
 
+    # Generate (but don't send) email now, so we are guaranteed to have a
+    # fully functioning DeputyAssignment object
+    email = build_notification_email_for_destroy(@deputy_assignment)
+
     DeputyAssignmentDeleteService.call(deputy_assignment: @deputy_assignment)
+    email.deliver_now
     flash.notice = t('.success')
   rescue ActiveRecord::RecordNotDestroyed, ActiveRecord::RecordInvalid
     flash.alert = t('.error')
@@ -62,5 +74,19 @@ class DeputyAssignmentsController < ProfileManagementController
         .partition(&:pending?)
 
       @deputy_assignments = pending + confirmed
+    end
+
+    def build_notification_email_for_destroy(deputy_assignment)
+      mailer_method = if current_user == deputy_assignment.primary
+                        :deputy_status_revoked
+                      elsif deputy_assignment.confirmed?
+                        :deputy_status_ended
+                      else
+                        :deputy_assignment_declination
+                      end
+
+      # `send` is confusing here, we are not sending an email, we are
+      # dynamically calling the method determined above
+      DeputyAssignmentsMailer.send(mailer_method, deputy_assignment)
     end
 end

--- a/app/forms/new_deputy_assignment_form.rb
+++ b/app/forms/new_deputy_assignment_form.rb
@@ -48,11 +48,14 @@ class NewDeputyAssignmentForm
         return nil
       end
 
+      # TODO this should be refactored along with
+      # User#attributes_from_psu_identity to share a common service
       new_user = User.new(
         webaccess_id: webaccess_id,
-        first_name: psu_identity.given_name,
-        last_name: psu_identity.family_name,
-        psu_identity: psu_identity
+        first_name: (psu_identity.preferred_given_name.presence || psu_identity.given_name),
+        last_name: (psu_identity.preferred_family_name.presence || psu_identity.family_name),
+        psu_identity: psu_identity,
+        psu_identity_updated_at: Time.zone.now
       )
 
       new_user.validate!

--- a/app/forms/new_deputy_assignment_form.rb
+++ b/app/forms/new_deputy_assignment_form.rb
@@ -8,6 +8,8 @@ class NewDeputyAssignmentForm
   attr_accessor :primary,
                 :deputy_webaccess_id
 
+  attr_reader :deputy_assignment
+
   validates :primary,
             presence: true
 
@@ -26,7 +28,7 @@ class NewDeputyAssignmentForm
       validate_deputy_assignment_does_not_already_exist(deputy: deputy)
       return false if errors.any?
 
-      create_deputy_assignment(primary: primary, deputy: deputy)
+      @deputy_assignment = create_deputy_assignment(primary: primary, deputy: deputy)
     rescue StandardError
       errors.add(:base, :unknown_error)
     end
@@ -41,7 +43,7 @@ class NewDeputyAssignmentForm
         initialize_user_from_psu_identity(webaccess_id: webaccess_id)
     end
 
-    def initialize_user_from_psu_identity(webaccess_id: webaccess_id)
+    def initialize_user_from_psu_identity(webaccess_id:)
       psu_identity = query_psu_identity(webaccess_id)
       if psu_identity.blank?
         errors.add(:deputy_webaccess_id, :not_found)

--- a/app/mailers/deputy_assignments_mailer.rb
+++ b/app/mailers/deputy_assignments_mailer.rb
@@ -2,9 +2,9 @@
 
 class DeputyAssignmentsMailer < ApplicationMailer
   def deputy_assignment_confirmation(deputy_assignment)
-    @primary = deputy_assignment.primary
+    @primary = UserProfile.new(deputy_assignment.primary)
     @deputy = deputy_assignment.deputy
-    @deputy_url = 'FIXME' # TODO: replace this with the actual URL
+    @deputy_url = deputy_assignments_url
     mail to: @primary.email,
          subject: 'PSU Researcher Metadata Database - Proxy Request Confirmed',
          from: 'openaccess@psu.edu',
@@ -12,7 +12,7 @@ class DeputyAssignmentsMailer < ApplicationMailer
   end
 
   def deputy_assignment_declination(deputy_assignment)
-    @primary = deputy_assignment.primary
+    @primary = UserProfile.new(deputy_assignment.primary)
     @deputy = deputy_assignment.deputy
     mail to: @primary.email,
          subject: 'PSU Researcher Metadata Database - Proxy Request Declined',
@@ -22,8 +22,8 @@ class DeputyAssignmentsMailer < ApplicationMailer
 
   def deputy_assignment_request(deputy_assignment)
     @primary = deputy_assignment.primary
-    @deputy = deputy_assignment.deputy
-    @deputy_url = 'FIXME' # TODO: replace this with the actual URL
+    @deputy = UserProfile.new(deputy_assignment.deputy)
+    @deputy_url = deputy_assignments_url
     mail to: @deputy.email,
          subject: 'PSU Researcher Metadata Database - Proxy Assignment Request',
          from: 'openaccess@psu.edu',
@@ -31,7 +31,7 @@ class DeputyAssignmentsMailer < ApplicationMailer
   end
 
   def deputy_status_ended(deputy_assignment)
-    @primary = deputy_assignment.primary
+    @primary = UserProfile.new(deputy_assignment.primary)
     @deputy = deputy_assignment.deputy
     mail to: @primary.email,
          subject: 'PSU Researcher Metadata Database - Proxy Status Ended',
@@ -41,7 +41,7 @@ class DeputyAssignmentsMailer < ApplicationMailer
 
   def deputy_status_revoked(deputy_assignment)
     @primary = deputy_assignment.primary
-    @deputy = deputy_assignment.deputy
+    @deputy = UserProfile.new(deputy_assignment.deputy)
     mail to: @deputy.email,
          subject: 'PSU Researcher Metadata Database - Proxy Status Revoked',
          from: 'openaccess@psu.edu',

--- a/spec/component/forms/new_deputy_assignment_form_spec.rb
+++ b/spec/component/forms/new_deputy_assignment_form_spec.rb
@@ -60,6 +60,7 @@ s.psu.edu/cpr/resources/123456" } }
           expect(deputy.first_name).to eq 'Deputy'
           expect(deputy.last_name).to eq 'FromPsu'
           expect(deputy.psu_identity).to be_present
+          expect(deputy.psu_identity_updated_at).to be_within(2.seconds).of(Time.zone.now)
         end
 
         it 'creates an active DeputyAssignment' do

--- a/spec/component/forms/new_deputy_assignment_form_spec.rb
+++ b/spec/component/forms/new_deputy_assignment_form_spec.rb
@@ -72,6 +72,15 @@ s.psu.edu/cpr/resources/123456" } }
           expect(assignment.primary).to eq primary
           expect(assignment.deputy.webaccess_id).to eq deputy_webaccess_id
         end
+
+        it 'sets :deputy_assignment to the newly created DeputyAssignment' do
+          expect {
+            form.save
+          }.to change(form, :deputy_assignment)
+            .from(nil).to(an_instance_of(DeputyAssignment))
+
+          expect(form.deputy_assignment).to eq DeputyAssignment.active.last
+        end
       end
 
       context 'when the webaccess_id is not found in PsuIdentity' do
@@ -91,6 +100,13 @@ s.psu.edu/cpr/resources/123456" } }
             form.save
           }.to not_change(User, :count)
             .and not_change(DeputyAssignment, :count)
+        end
+
+        it 'does not set :deputy_assignment' do
+          expect {
+            form.save
+          }.not_to change(form, :deputy_assignment)
+            .from(nil)
         end
       end
 

--- a/spec/component/mailers/deputy_assignments_mailer_spec.rb
+++ b/spec/component/mailers/deputy_assignments_mailer_spec.rb
@@ -3,25 +3,31 @@
 require 'component/component_spec_helper'
 
 describe DeputyAssignmentsMailer, type: :model do
-  let(:primary) { double 'user',
-                         email: 'primary@psu.edu',
-                         name: 'Primary User',
-                         webaccess_id: 'abc123' }
+  include Rails.application.routes.url_helpers
 
-  let(:deputy) { double 'user',
-                        email: 'deputy@psu.edu',
-                        name: 'Deputy User',
-                        webaccess_id: 'def456' }
+  let(:primary) { instance_double 'User',
+                                  name: 'Primary User',
+                                  webaccess_id: 'abc123',
+                                  psu_identity_updated_at: Time.zone.now }
 
-  let(:deputy_assignment) { double 'deputy_assignment',
-                                   primary: primary,
-                                   deputy: deputy }
+  let(:deputy) { instance_double 'User',
+                                 name: 'Deputy User',
+                                 webaccess_id: 'def456',
+                                 psu_identity_updated_at: Time.zone.now }
+
+  let(:deputy_assignment) { instance_double 'DeputyAssignment',
+                                            primary: primary,
+                                            deputy: deputy }
+
+  before do
+    allow(ActionMailer::Base).to receive(:default_url_options).and_return({ host: 'example.com' })
+  end
 
   describe '#deputy_assignment_confirmation' do
     subject(:email) { described_class.deputy_assignment_confirmation(deputy_assignment) }
 
     it "sends the email to the primary user's email address" do
-      expect(email.to).to eq ['primary@psu.edu']
+      expect(email.to).to eq ['abc123@psu.edu']
     end
 
     it 'sends the email from the correct address' do
@@ -46,6 +52,10 @@ describe DeputyAssignmentsMailer, type: :model do
       it 'mentions the deputy by name and webaccess ID' do
         expect(body).to include('Deputy User (def456)')
       end
+
+      it 'has a link to the deputy assignments page' do
+        expect(body).to include(deputy_assignments_url(host: 'example.com'))
+      end
     end
   end
 
@@ -53,7 +63,7 @@ describe DeputyAssignmentsMailer, type: :model do
     subject(:email) { described_class.deputy_assignment_declination(deputy_assignment) }
 
     it "sends the email to the primary user's email address" do
-      expect(email.to).to eq ['primary@psu.edu']
+      expect(email.to).to eq ['abc123@psu.edu']
     end
 
     it 'sends the email from the correct address' do
@@ -84,12 +94,8 @@ describe DeputyAssignmentsMailer, type: :model do
   describe '#deputy_assignment_request' do
     subject(:email) { described_class.deputy_assignment_request(deputy_assignment) }
 
-    before do
-      allow(ActionMailer::Base).to receive(:default_url_options).and_return({ host: 'example.com' })
-    end
-
     it "sends the email to the deputy user's email address" do
-      expect(email.to).to eq ['deputy@psu.edu']
+      expect(email.to).to eq ['def456@psu.edu']
     end
 
     it 'sends the email from the correct address' do
@@ -110,6 +116,10 @@ describe DeputyAssignmentsMailer, type: :model do
       it 'addresses the user by name' do
         expect(body).to include('Dear Deputy User,')
       end
+
+      it 'has a link to the deputy assignments page' do
+        expect(body).to include(deputy_assignments_url(host: 'example.com'))
+      end
     end
   end
 
@@ -117,7 +127,7 @@ describe DeputyAssignmentsMailer, type: :model do
     subject(:email) { described_class.deputy_status_ended(deputy_assignment) }
 
     it "sends the email to the primary user's email address" do
-      expect(email.to).to eq ['primary@psu.edu']
+      expect(email.to).to eq ['abc123@psu.edu']
     end
 
     it 'sends the email from the correct address' do
@@ -149,7 +159,7 @@ describe DeputyAssignmentsMailer, type: :model do
     subject(:email) { described_class.deputy_status_revoked(deputy_assignment) }
 
     it "sends the email to the deputy user's email address" do
-      expect(email.to).to eq ['deputy@psu.edu']
+      expect(email.to).to eq ['def456@psu.edu']
     end
 
     it 'sends the email from the correct address' do

--- a/spec/factories/deputy_assignment.rb
+++ b/spec/factories/deputy_assignment.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :deputy_assignment do
-    primary factory: :user
-    deputy factory: :user
+    primary factory: [:user, :with_psu_identity]
+    deputy factory: [:user, :with_psu_identity]
     is_active { true }
     confirmed_at { Time.zone.now }
 

--- a/spec/integration/profiles/deputy_assignments/confirm_spec.rb
+++ b/spec/integration/profiles/deputy_assignments/confirm_spec.rb
@@ -16,23 +16,28 @@ describe 'Confirming a Proxy', type: :feature do
     let!(:user) { create :user }
     let!(:deputy_assignment) { create :deputy_assignment, :unconfirmed, :active, deputy: user }
 
+    let(:accept_button) { I18n.t!('view_component.deputy_assignment_component.accept') }
+
     before do
       authenticate_as(user)
       visit deputy_assignments_path
-    end
-
-    it 'allows a pending deputy assignment to be confirmed' do
-      accept_button = I18n.t!('view_component.deputy_assignment_component.accept')
 
       within "##{dom_id(deputy_assignment)}" do
         click_on accept_button
       end
+    end
 
+    it 'allows a pending deputy assignment to be confirmed' do
       expect(deputy_assignment.reload).to be_confirmed
 
       within "##{dom_id(deputy_assignment)}" do
         expect(page).not_to have_button(accept_button)
       end
+    end
+
+    it 'emails the primary' do
+      open_email("#{deputy_assignment.primary.webaccess_id}@psu.edu")
+      expect(current_email.subject).to match(/proxy request confirmed/i)
     end
   end
 end

--- a/spec/integration/profiles/deputy_assignments/create_spec.rb
+++ b/spec/integration/profiles/deputy_assignments/create_spec.rb
@@ -20,14 +20,21 @@ describe 'Creating a new proxy', type: :feature do
     end
 
     context 'when all goes well' do
-      it 'creates a DeputyAssignment' do
+      before do
         fill_in 'new_deputy_assignment_form_deputy_webaccess_id', with: 'agw13'
         click_button I18n.t!('helpers.submit.new_deputy_assignment_form.create')
+      end
 
+      it 'creates a DeputyAssignment' do
         da = DeputyAssignment.active.where(primary: user).last
         expect(da).to be_present
         expect(da.deputy.webaccess_id).to eq 'agw13'
         expect(page).to have_content da.deputy.name
+      end
+
+      it 'emails the deputy of the assignment' do
+        open_email('agw13@psu.edu')
+        expect(current_email.subject).to match(/proxy assignment request/i)
       end
     end
 

--- a/spec/integration/profiles/deputy_assignments/destroy_spec.rb
+++ b/spec/integration/profiles/deputy_assignments/destroy_spec.rb
@@ -13,23 +13,47 @@ describe 'Destroying a Proxy', type: :feature do
   end
 
   context 'when logged in' do
-    let!(:user) { deputy_assignment.primary }
-    let!(:deputy_assignment) { create :deputy_assignment, :confirmed, :active }
-
     before do
       authenticate_as(user)
       visit deputy_assignments_path
-    end
-
-    it 'allows a pending deputy assignment to be destroyed' do
-      destroy_button = I18n.t!('view_component.deputy_assignment_component.delete_as_primary')
 
       within "##{dom_id(deputy_assignment)}" do
         click_on destroy_button
       end
+    end
 
-      expect(deputy_assignment.reload).not_to be_active
-      expect(page).not_to have_selector "##{dom_id(deputy_assignment)}"
+    context 'when the DeputyAssignment is deactivated, but not destroyed in the db' do
+      let!(:deputy_assignment) { create :deputy_assignment, :confirmed, :active }
+      let!(:user) { deputy_assignment.primary }
+      let!(:other) { deputy_assignment.deputy }
+      let(:destroy_button) { I18n.t!('view_component.deputy_assignment_component.delete_as_primary') }
+
+      it 'allows the deputy assignment to be deactivated' do
+        expect(deputy_assignment.reload).not_to be_active
+        expect(page).not_to have_selector "##{dom_id(deputy_assignment)}"
+      end
+
+      it 'emails the other user' do
+        open_email("#{other.webaccess_id}@psu.edu")
+        expect(current_email.subject).to match(/proxy status revoked/i)
+      end
+    end
+
+    context 'when the DeputyAssignment is actually destroyed in the db' do
+      let!(:deputy_assignment) { create :deputy_assignment, :unconfirmed, :active }
+      let!(:user) { deputy_assignment.deputy }
+      let!(:other) { deputy_assignment.primary }
+      let(:destroy_button) { I18n.t!('view_component.deputy_assignment_component.delete_as_deputy_unconfirmed') }
+
+      it 'allows the deputy assignment to be destroyed' do
+        expect { deputy_assignment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(page).not_to have_selector "##{dom_id(deputy_assignment)}"
+      end
+
+      it 'emails the other user' do
+        open_email("#{other.webaccess_id}@psu.edu")
+        expect(current_email.subject).to match(/proxy request declined/i)
+      end
     end
   end
 end


### PR DESCRIPTION
Whenever someone does anything with DeputyAssignments, it emails the other party:
* Creation: emails the deputy
* Deputy confirms: emails the primary
* Deputy declines: emails the primary
* Primary revokes: emails the deputy
* Deputy breaks up with primary: emails the primary a youtube to Kelly Clarkson - Since You've Been Gone [looped for 10 hours](https://www.youtube.com/watch?v=83D5T8eue9s)

This also includes some slight changes to the `NewDeputyAssignmentForm` object to create fields that match what `User#attributes_from_psu_identity` does. I did not actually use the latter method because it didn't give me enough control over the error handling. @awead and I are going to refactor both of the aforementioned methods to use a common service class.

Closes #332 