### PR TITLE
BaseDecorator maintains `==` with a decorated ActiveRecord model

### DIFF
--- a/app/decorators/base_decorator.rb
+++ b/app/decorators/base_decorator.rb
@@ -11,9 +11,9 @@ class BaseDecorator < SimpleDelegator
     __getobj__
   end
 
-  # @note Ensures that type checks return the expected classes. This was causing ActiveRecord.where and .find_by
-  # operations not to work.
-  def is_a?(klass)
-    __getobj__.is_a?(klass)
-  end
+  # @note Ensures that type checks return the expected classes. This was causing ActiveRecord.where, .find_by,
+  # route helpers, and == operations not to work.
+  delegate :is_a?,
+           :instance_of?,
+           to: :__getobj__
 end

--- a/spec/component/decorators/user_decorator_spec.rb
+++ b/spec/component/decorators/user_decorator_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-require 'unit/unit_spec_helper'
-require 'active_support'
-require 'active_support/core_ext'
-require_relative '../../../app/decorators/base_decorator'
-require_relative '../../../app/decorators/user_decorator'
+require 'component/component_spec_helper'
 
 describe UserDecorator do
   describe 'masquerading?' do
@@ -21,6 +17,17 @@ describe UserDecorator do
       subject { described_class.new(user: mock_user) }
 
       it { is_expected.not_to be_masquerading }
+    end
+  end
+
+  describe 'equality' do
+    subject(:decorator) { described_class.new(user: user) }
+
+    let(:user) { build_stubbed :user }
+
+    it 'has symmetric ==' do
+      expect(decorator == user).to eq true
+      expect(user == decorator).to eq true
     end
   end
 end

--- a/spec/unit/decorators/base_decorator_spec.rb
+++ b/spec/unit/decorators/base_decorator_spec.rb
@@ -28,4 +28,8 @@ describe BaseDecorator do
     specify { expect(decorator).not_to be_a(String) }
   end
   # rubocop:enable RSpec/PredicateMatcher
+
+  describe '#instance_of?' do
+    specify { expect(decorator.instance_of?(mock.class)).to eq true }
+  end
 end


### PR DESCRIPTION
Closes #377 