### PR TITLE
Add the deputy user id to related resources

### DIFF
--- a/app/controllers/external_publication_waivers_controller.rb
+++ b/app/controllers/external_publication_waivers_controller.rb
@@ -6,7 +6,9 @@ class ExternalPublicationWaiversController < ProfileManagementController
   end
 
   def create
-    @waiver = current_user.external_publication_waivers.build(waiver_params)
+    @waiver = current_user
+      .external_publication_waivers
+      .build(waiver_params.merge(deputy_user_id: current_user.deputy.id))
     @waiver.save!
     flash[:notice] = I18n.t('profile.external_publication_waivers.create.success')
     FacultyConfirmationsMailer.open_access_waiver_confirmation(UserProfile.new(current_user), @waiver).deliver_now

--- a/app/controllers/internal_publication_waivers_controller.rb
+++ b/app/controllers/internal_publication_waivers_controller.rb
@@ -8,7 +8,7 @@ class InternalPublicationWaiversController < OpenAccessWorkflowController
 
   def create
     authorship = current_user.confirmed_authorships.find_by!(publication_id: params[:id])
-    waiver = InternalPublicationWaiver.new(waiver_params)
+    waiver = InternalPublicationWaiver.new(waiver_params.merge(deputy_user_id: current_user.deputy.id))
     waiver.authorship = authorship
     waiver.save!
 

--- a/app/controllers/open_access_publications_controller.rb
+++ b/app/controllers/open_access_publications_controller.rb
@@ -21,6 +21,7 @@ class OpenAccessPublicationsController < OpenAccessWorkflowController
     if @form.valid?
       oal = publication.open_access_locations.find_or_initialize_by(source: Source::USER)
       oal.url = @form.open_access_url
+      oal.deputy_user_id = current_user.deputy.id
       oal.save!
 
       flash[:notice] = I18n.t('profile.open_access_publications.update.success')
@@ -36,7 +37,7 @@ class OpenAccessPublicationsController < OpenAccessWorkflowController
 
   def create_scholarsphere_deposit
     @authorship = Authorship.find_by(user: current_user, publication: publication)
-    extra_params = { authorship: @authorship }
+    extra_params = { authorship: @authorship, deputy_user_id: current_user.deputy.id }
     @deposit = ScholarsphereWorkDeposit.new(deposit_params.merge(extra_params))
 
     ActiveRecord::Base.transaction do

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 class UserDecorator < BaseDecorator
-  attr_reader :impersonator
-
   def initialize(user:, impersonator: nil)
     @impersonator = impersonator
     super(user)
   end
+
+  def impersonator
+    @impersonator ||= NullUser.new
+  end
+  alias :deputy :impersonator
 
   def masquerading?
     impersonator.present?

--- a/app/models/concerns/deputy_user.rb
+++ b/app/models/concerns/deputy_user.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DeputyUser
+  extend ActiveSupport::Concern
+
+  included do
+    # rubocop:disable Rails/InverseOf
+    belongs_to :deputy,
+               class_name: 'User',
+               foreign_key: :deputy_user_id,
+               optional: true
+    # rubocop:enable Rails/InverseOf
+
+    validate :deputy_must_be_assigned
+  end
+
+  private
+
+    # @note We can't tell (easily) if the deputy is associated with the exact user, but we can tell if they have any
+    # valid primary users.
+    def deputy_must_be_assigned
+      return if deputy.nil?
+
+      errors.add(:deputy, :not_assigned) if deputy.deputy_assignments.limit(1).empty?
+    end
+end

--- a/app/models/external_publication_waiver.rb
+++ b/app/models/external_publication_waiver.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ExternalPublicationWaiver < ApplicationRecord
+  include DeputyUser
+
   belongs_to :user, inverse_of: :external_publication_waivers
   belongs_to :internal_publication_waiver, inverse_of: :external_publication_waiver, optional: true
 

--- a/app/models/internal_publication_waiver.rb
+++ b/app/models/internal_publication_waiver.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class InternalPublicationWaiver < ApplicationRecord
+  include DeputyUser
+
   belongs_to :authorship, inverse_of: :waiver
   has_one :user, through: :authorship
   has_one :publication, through: :authorship

--- a/app/models/open_access_location.rb
+++ b/app/models/open_access_location.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class OpenAccessLocation < ApplicationRecord
+  include DeputyUser
+
   enum source: to_enum_hash([
                               Source::USER,
                               Source::SCHOLARSPHERE,

--- a/app/models/scholarsphere_work_deposit.rb
+++ b/app/models/scholarsphere_work_deposit.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ScholarsphereWorkDeposit < ApplicationRecord
+  include DeputyUser
+
   def self.statuses
     ['Pending', 'Success', 'Failed']
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,22 @@ en:
               is_admin: 'cannot be an administrator'
             primary:
               is_admin: 'cannot be an administrator'
+        external_publication_waiver:
+          attributes:
+            deputy:
+              not_assigned: 'is not a assigned or available deputy'
+        internal_publication_waiver:
+          attributes:
+            deputy:
+              not_assigned: 'is not a assigned or available deputy'
+        open_access_location:
+          attributes:
+            deputy:
+              not_assigned: 'is not a assigned or available deputy'
+        scholarsphere_work_deposit:
+          attributes:
+            deputy:
+              not_assigned: 'is not a assigned or available deputy'
   admin:
     authorization:
       not_authorized: "Your account is not authorized to perform this action."

--- a/db/migrate/20211108163408_add_deputy_user_id_to_open_access_locations.rb
+++ b/db/migrate/20211108163408_add_deputy_user_id_to_open_access_locations.rb
@@ -1,0 +1,9 @@
+class AddDeputyUserIdToOpenAccessLocations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :open_access_locations, :deputy_user_id, :bigint, null: true
+    add_index :open_access_locations, :deputy_user_id
+    add_foreign_key :open_access_locations, :users,
+      column: :deputy_user_id,
+      name: :open_access_locations_deputy_user_id_fk
+  end
+end

--- a/db/migrate/20211109151802_add_deputy_user_id_to_external_publication_waivers.rb
+++ b/db/migrate/20211109151802_add_deputy_user_id_to_external_publication_waivers.rb
@@ -1,0 +1,9 @@
+class AddDeputyUserIdToExternalPublicationWaivers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :external_publication_waivers, :deputy_user_id, :bigint, null: true
+    add_index :external_publication_waivers, :deputy_user_id
+    add_foreign_key :external_publication_waivers, :users,
+      column: :deputy_user_id,
+      name: :external_publication_waivers_deputy_user_id_fk
+  end
+end

--- a/db/migrate/20211109153618_add_deputy_user_id_to_internal_publication_waivers.rb
+++ b/db/migrate/20211109153618_add_deputy_user_id_to_internal_publication_waivers.rb
@@ -1,0 +1,9 @@
+class AddDeputyUserIdToInternalPublicationWaivers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :internal_publication_waivers, :deputy_user_id, :bigint, null: true
+    add_index :internal_publication_waivers, :deputy_user_id
+    add_foreign_key :internal_publication_waivers, :users,
+      column: :deputy_user_id,
+      name: :internal_publication_waivers_deputy_user_id_fk
+  end
+end

--- a/db/migrate/20211109153954_add_deputy_user_id_to_scholarsphere_work_deposits.rb
+++ b/db/migrate/20211109153954_add_deputy_user_id_to_scholarsphere_work_deposits.rb
@@ -1,0 +1,9 @@
+class AddDeputyUserIdToScholarsphereWorkDeposits < ActiveRecord::Migration[6.1]
+  def change
+    add_column :scholarsphere_work_deposits, :deputy_user_id, :bigint, null: true
+    add_index :scholarsphere_work_deposits, :deputy_user_id
+    add_foreign_key :scholarsphere_work_deposits, :users,
+      column: :deputy_user_id,
+      name: :scholarsphere_work_deposits_deputy_user_id_fk
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_05_202204) do
+ActiveRecord::Schema.define(version: 2021_11_09_153954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -217,6 +217,8 @@ ActiveRecord::Schema.define(version: 2021_11_05_202204) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "internal_publication_waiver_id"
+    t.bigint "deputy_user_id"
+    t.index ["deputy_user_id"], name: "index_external_publication_waivers_on_deputy_user_id"
     t.index ["internal_publication_waiver_id"], name: "index_external_waivers_on_internal_waiver_id"
     t.index ["user_id"], name: "index_external_publication_waivers_on_user_id"
   end
@@ -256,7 +258,9 @@ ActiveRecord::Schema.define(version: 2021_11_05_202204) do
     t.text "reason_for_waiver"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "deputy_user_id"
     t.index ["authorship_id"], name: "index_internal_publication_waivers_on_authorship_id"
+    t.index ["deputy_user_id"], name: "index_internal_publication_waivers_on_deputy_user_id"
   end
 
   create_table "journals", force: :cascade do |t|
@@ -307,6 +311,8 @@ ActiveRecord::Schema.define(version: 2021_11_05_202204) do
     t.string "version"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "deputy_user_id"
+    t.index ["deputy_user_id"], name: "index_open_access_locations_on_deputy_user_id"
     t.index ["publication_id"], name: "index_open_access_locations_on_publication_id"
   end
 
@@ -512,7 +518,9 @@ ActiveRecord::Schema.define(version: 2021_11_05_202204) do
     t.text "subtitle"
     t.string "publisher"
     t.text "publisher_statement"
+    t.bigint "deputy_user_id"
     t.index ["authorship_id"], name: "index_scholarsphere_work_deposits_on_authorship_id"
+    t.index ["deputy_user_id"], name: "index_scholarsphere_work_deposits_on_deputy_user_id"
   end
 
   create_table "statistics_snapshots", force: :cascade do |t|
@@ -641,13 +649,16 @@ ActiveRecord::Schema.define(version: 2021_11_05_202204) do
   add_foreign_key "education_history_items", "users", on_delete: :cascade
   add_foreign_key "email_errors", "users", name: "email_errors_user_id_fk"
   add_foreign_key "external_publication_waivers", "internal_publication_waivers", name: "external_publication_waivers_internal_publication_waiver_id_fk"
+  add_foreign_key "external_publication_waivers", "users", column: "deputy_user_id", name: "external_publication_waivers_deputy_user_id_fk"
   add_foreign_key "external_publication_waivers", "users", name: "external_publication_waivers_user_id_fk"
   add_foreign_key "internal_publication_waivers", "authorships", name: "internal_publication_waivers_authorship_id_fk"
+  add_foreign_key "internal_publication_waivers", "users", column: "deputy_user_id", name: "internal_publication_waivers_deputy_user_id_fk"
   add_foreign_key "journals", "publishers"
   add_foreign_key "news_feed_items", "users"
   add_foreign_key "non_duplicate_publication_group_memberships", "non_duplicate_publication_groups", name: "non_duplicate_publication_group_membership_group_id_fk", on_delete: :cascade
   add_foreign_key "non_duplicate_publication_group_memberships", "publications", name: "non_duplicate_publication_group_membership_publication_id_fk", on_delete: :cascade
   add_foreign_key "open_access_locations", "publications", name: "open_access_locations_publication_id_fk", on_delete: :cascade
+  add_foreign_key "open_access_locations", "users", column: "deputy_user_id", name: "open_access_locations_deputy_user_id_fk"
   add_foreign_key "organization_api_permissions", "api_tokens", name: "organization_api_permissions_api_token_id_fk", on_delete: :cascade
   add_foreign_key "organization_api_permissions", "organizations", name: "organization_api_permissions_organization_id_fk", on_delete: :cascade
   add_foreign_key "organizations", "organizations", column: "parent_id", name: "organizations_parent_id_fk", on_delete: :restrict
@@ -666,6 +677,7 @@ ActiveRecord::Schema.define(version: 2021_11_05_202204) do
   add_foreign_key "researcher_funds", "users", name: "research_funds_user_id_fk", on_delete: :cascade
   add_foreign_key "scholarsphere_file_uploads", "scholarsphere_work_deposits", name: "scholarsphere_file_uploads_deposit_id_fk"
   add_foreign_key "scholarsphere_work_deposits", "authorships"
+  add_foreign_key "scholarsphere_work_deposits", "users", column: "deputy_user_id", name: "scholarsphere_work_deposits_deputy_user_id_fk"
   add_foreign_key "user_contracts", "contracts", on_delete: :cascade
   add_foreign_key "user_contracts", "users", on_delete: :cascade
   add_foreign_key "user_organization_memberships", "organizations", name: "user_organization_memberships_organization_id_fk", on_delete: :cascade

--- a/spec/component/models/external_publication_waiver_spec.rb
+++ b/spec/component/models/external_publication_waiver_spec.rb
@@ -2,6 +2,7 @@
 
 require 'component/component_spec_helper'
 require 'component/models/shared_examples_for_an_application_record'
+require 'component/models/shared_examples_for_a_model_with_a_deputy_user'
 
 describe 'the external_publication_waivers table', type: :model do
   subject { ExternalPublicationWaiver.new }
@@ -16,16 +17,20 @@ describe 'the external_publication_waivers table', type: :model do
   it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
   it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
   it { is_expected.to have_db_column(:internal_publication_waiver_id).of_type(:integer) }
+  it { is_expected.to have_db_column(:deputy_user_id).of_type(:integer) }
 
   it { is_expected.to have_db_index :user_id }
   it { is_expected.to have_db_index :internal_publication_waiver_id }
+  it { is_expected.to have_db_index :deputy_user_id }
 
   it { is_expected.to have_db_foreign_key(:user_id) }
   it { is_expected.to have_db_foreign_key(:internal_publication_waiver_id) }
+  it { is_expected.to have_db_foreign_key(:deputy_user_id).to_table(:users).with_name(:external_publication_waivers_deputy_user_id_fk) }
 end
 
 describe ExternalPublicationWaiver, type: :model do
   it_behaves_like 'an application record'
+  it_behaves_like 'a model with a deputy user'
 
   describe 'associations' do
     it { is_expected.to belong_to(:user).inverse_of(:external_publication_waivers) }

--- a/spec/component/models/internal_publication_waiver_spec.rb
+++ b/spec/component/models/internal_publication_waiver_spec.rb
@@ -2,6 +2,7 @@
 
 require 'component/component_spec_helper'
 require 'component/models/shared_examples_for_an_application_record'
+require 'component/models/shared_examples_for_a_model_with_a_deputy_user'
 
 describe 'the internal_publication_waivers table', type: :model do
   subject { InternalPublicationWaiver.new }
@@ -10,16 +11,20 @@ describe 'the internal_publication_waivers table', type: :model do
   it { is_expected.to have_db_column(:reason_for_waiver).of_type(:text) }
   it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
   it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+  it { is_expected.to have_db_column(:deputy_user_id).of_type(:integer) }
 
   it { is_expected.to have_db_index :authorship_id }
+  it { is_expected.to have_db_index :deputy_user_id }
 
   it { is_expected.to have_db_foreign_key(:authorship_id) }
+  it { is_expected.to have_db_foreign_key(:deputy_user_id).to_table(:users).with_name(:internal_publication_waivers_deputy_user_id_fk) }
 end
 
 describe InternalPublicationWaiver, type: :model do
   subject(:waiver) { described_class.new }
 
   it_behaves_like 'an application record'
+  it_behaves_like 'a model with a deputy user'
 
   describe 'associations' do
     it { is_expected.to belong_to(:authorship).inverse_of(:waiver) }

--- a/spec/component/models/open_access_location_spec.rb
+++ b/spec/component/models/open_access_location_spec.rb
@@ -2,6 +2,7 @@
 
 require 'component/component_spec_helper'
 require 'component/models/shared_examples_for_an_application_record'
+require 'component/models/shared_examples_for_a_model_with_a_deputy_user'
 
 describe 'the open_access_locations table', type: :model do
   subject { OpenAccessLocation.new }
@@ -20,16 +21,20 @@ describe 'the open_access_locations table', type: :model do
   it { is_expected.to have_db_column(:version).of_type(:string) }
   it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
   it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+  it { is_expected.to have_db_column(:deputy_user_id).of_type(:integer) }
 
   it { is_expected.to have_db_index :publication_id }
+  it { is_expected.to have_db_index :deputy_user_id }
 
   it { is_expected.to have_db_foreign_key(:publication_id) }
+  it { is_expected.to have_db_foreign_key(:deputy_user_id).to_table(:users).with_name(:open_access_locations_deputy_user_id_fk) }
 end
 
 describe OpenAccessLocation, type: :model do
   subject(:oal) { described_class.new }
 
   it_behaves_like 'an application record'
+  it_behaves_like 'a model with a deputy user'
 
   describe 'associations' do
     it { is_expected.to belong_to(:publication).inverse_of(:open_access_locations) }

--- a/spec/component/models/scholarsphere_work_deposit_spec.rb
+++ b/spec/component/models/scholarsphere_work_deposit_spec.rb
@@ -2,6 +2,7 @@
 
 require 'component/component_spec_helper'
 require 'component/models/shared_examples_for_an_application_record'
+require 'component/models/shared_examples_for_a_model_with_a_deputy_user'
 
 describe 'the scholarsphere_work_deposits table', type: :model do
   subject { ScholarsphereWorkDeposit.new }
@@ -22,10 +23,17 @@ describe 'the scholarsphere_work_deposits table', type: :model do
   it { is_expected.to have_db_column(:publisher).of_type(:string) }
   it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
   it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+  it { is_expected.to have_db_column(:deputy_user_id).of_type(:integer) }
 
   it { is_expected.to have_db_index(:authorship_id) }
+  it { is_expected.to have_db_index :deputy_user_id }
 
   it { is_expected.to have_db_foreign_key(:authorship_id) }
+  it { is_expected.to have_db_foreign_key(:deputy_user_id).to_table(:users).with_name(:scholarsphere_work_deposits_deputy_user_id_fk) }
+end
+
+describe ScholarsphereWorkDeposit, type: :model do
+  it_behaves_like 'a model with a deputy user'
 end
 
 describe ScholarsphereFileUpload, type: :model do

--- a/spec/component/models/shared_examples_for_a_model_with_a_deputy_user.rb
+++ b/spec/component/models/shared_examples_for_a_model_with_a_deputy_user.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+shared_examples_for 'a model with a deputy user' do
+  subject(:example) { described_class.new }
+
+  context 'when setting the deputy with a valid user' do
+    let(:user) { create(:user, primaries: [primary_user]) }
+    let(:primary_user) { create(:user) }
+
+    it { is_expected.to allow_value(user).for(:deputy) }
+  end
+
+  context 'when setting the deputy with an invalid user' do
+    let(:user) { create(:user) }
+    let(:primary_user) { create(:user) }
+
+    it { is_expected.not_to allow_value(user).for(:deputy) }
+
+    describe 'the error message' do
+      subject { example.errors[:deputy] }
+
+      before do
+        example.deputy = user
+        example.validate
+      end
+
+      let(:message) do
+        I18n.t!("activerecord.errors.models.#{example.model_name.i18n_key}.attributes.deputy.not_assigned")
+      end
+
+      it { is_expected.to include(message) }
+    end
+  end
+end

--- a/spec/integration/profiles/external_publication_waivers/create_spec.rb
+++ b/spec/integration/profiles/external_publication_waivers/create_spec.rb
@@ -9,13 +9,82 @@ describe 'submitting an open access waiver for a publication that is not in the 
                       first_name: 'Test',
                       last_name: 'User' }
 
-  before do
-    authenticate_as(user)
-    visit new_external_publication_waiver_path
+  context 'with an authenticated primary user' do
+    before do
+      authenticate_as(user)
+      visit new_external_publication_waiver_path
+    end
+
+    context 'successfully submitting the form' do
+      before do
+        fill_in 'Publication Title', with: 'My Test Publication'
+        fill_in 'Reason for waiver', with: 'Because.'
+        fill_in 'Abstract', with: 'The abstract text.'
+        fill_in 'Digital Object Identifier (DOI)', with: 'https://doi.org/the-doi'
+        fill_in 'Journal', with: 'Test Journal'
+        fill_in 'Publisher', with: 'Test Publisher'
+        click_button 'Submit'
+      end
+
+      it 'saves the submitted data' do
+        w = ExternalPublicationWaiver.find_by(publication_title: 'My Test Publication')
+
+        expect(w.reason_for_waiver).to eq 'Because.'
+        expect(w.abstract).to eq 'The abstract text.'
+        expect(w.doi).to eq 'https://doi.org/the-doi'
+        expect(w.journal_title).to eq 'Test Journal'
+        expect(w.publisher).to eq 'Test Publisher'
+        expect(w.deputy_user_id).to be_nil
+      end
+
+      it 'redirects back to the publication list' do
+        expect(page).to have_current_path edit_profile_publications_path, ignore_query: true
+      end
+
+      it 'shows a success message' do
+        expect(page).to have_content I18n.t('profile.external_publication_waivers.create.success')
+      end
+
+      it 'sends a confirmation email to the user' do
+        open_email('test123@psu.edu')
+        expect(current_email).not_to be_nil
+        expect(current_email.subject).to match(/PSU Open Access Policy Waiver for Requested Article/i)
+        expect(current_email.body).to match(/Test User/)
+        expect(current_email.body).to match(/My Test Publication/)
+        expect(current_email.body).to match(/Test Journal/)
+      end
+    end
+
+    context 'submitting the form with errors' do
+      before do
+        fill_in 'Publication Title', with: 'My Test Publication'
+        fill_in 'Reason for waiver', with: 'Because.'
+        click_button 'Submit'
+      end
+
+      it 'does not save the waiver data' do
+        expect(ExternalPublicationWaiver.find_by(publication_title: 'My Test Publication')).to be_nil
+      end
+
+      it 'rerenders the form' do
+        expect(page).to have_current_path external_publication_waivers_path, ignore_query: true
+        expect(page.find_field('Reason for waiver').value).to eq 'Because.'
+      end
+
+      it 'shows an error message' do
+        expect(page).to have_content "Validation failed: Journal title can't be blank"
+      end
+    end
   end
 
-  context 'successfully submitting the form' do
+  context 'when submitting as a deputy for the primary user' do
+    let(:deputy) { create(:user) }
+
     before do
+      create(:deputy_assignment, primary: user, deputy: deputy)
+      impersonate_user(primary: user, deputy: deputy)
+      visit new_external_publication_waiver_path
+
       fill_in 'Publication Title', with: 'My Test Publication'
       fill_in 'Reason for waiver', with: 'Because.'
       fill_in 'Abstract', with: 'The abstract text.'
@@ -25,52 +94,10 @@ describe 'submitting an open access waiver for a publication that is not in the 
       click_button 'Submit'
     end
 
-    it 'saves the submitted data' do
+    it 'saves with waiver with the deputy user id' do
       w = ExternalPublicationWaiver.find_by(publication_title: 'My Test Publication')
 
-      expect(w.reason_for_waiver).to eq 'Because.'
-      expect(w.abstract).to eq 'The abstract text.'
-      expect(w.doi).to eq 'https://doi.org/the-doi'
-      expect(w.journal_title).to eq 'Test Journal'
-      expect(w.publisher).to eq 'Test Publisher'
-    end
-
-    it 'redirects back to the publication list' do
-      expect(page).to have_current_path edit_profile_publications_path, ignore_query: true
-    end
-
-    it 'shows a success message' do
-      expect(page).to have_content I18n.t('profile.external_publication_waivers.create.success')
-    end
-
-    it 'sends a confirmation email to the user' do
-      open_email('test123@psu.edu')
-      expect(current_email).not_to be_nil
-      expect(current_email.subject).to match(/PSU Open Access Policy Waiver for Requested Article/i)
-      expect(current_email.body).to match(/Test User/)
-      expect(current_email.body).to match(/My Test Publication/)
-      expect(current_email.body).to match(/Test Journal/)
-    end
-  end
-
-  context 'submitting the form with errors' do
-    before do
-      fill_in 'Publication Title', with: 'My Test Publication'
-      fill_in 'Reason for waiver', with: 'Because.'
-      click_button 'Submit'
-    end
-
-    it 'does not save the waiver data' do
-      expect(ExternalPublicationWaiver.find_by(publication_title: 'My Test Publication')).to be_nil
-    end
-
-    it 'rerenders the form' do
-      expect(page).to have_current_path external_publication_waivers_path, ignore_query: true
-      expect(page.find_field('Reason for waiver').value).to eq 'Because.'
-    end
-
-    it 'shows an error message' do
-      expect(page).to have_content "Validation failed: Journal title can't be blank"
+      expect(w.deputy_user_id).to eq deputy.id
     end
   end
 end

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -28,6 +28,12 @@ def authenticate_as(user)
   click_on 'Sign in'
 end
 
+def impersonate_user(primary:, deputy:)
+  authenticate_as(deputy)
+  visit profile_path(webaccess_id: primary.webaccess_id)
+  click_link('Become this user')
+end
+
 def authenticate_user
   sign_in_as current_user
   visit root_path


### PR DESCRIPTION
The first commit adds the deputy user id to the related database tables via an included module. The Rails relation only does the belongs_to side of it, and not the has_many/has_one. This is for simplicity's sake and because we don't need the reverse associations.

The second commit adds the deputy's id to the different controllers that create the resource with associated deputy user ids. The deputy user id is always added as a parameter, but if the current user isn't acting as a deputy, the id will be nil.

Fixes #338 