### PR TITLE
AI Importer: import the 'ACCESIBLE' field from AI publications

### DIFF
--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -154,7 +154,7 @@ class ActivityInsightImporter
             pub_record = pi.publication
 
             if pi.persisted?
-              pub_record.update!(pub_attrs(pub)) if pub_record.updated_by_user_at.blank?
+              update_pub_record(pub_record, pub)
             else
               pi.save!
             end
@@ -202,6 +202,22 @@ class ActivityInsightImporter
   end
 
   private
+
+    def update_pub_record(pub_record, ai_pub)
+      if pub_record.updated_by_user_at.blank?
+        pub_record.update!(pub_attrs(ai_pub))
+      else
+        # If the publication has been updated by an admin, we only want to
+        # overwrite a subset of its attributes.
+        pub_record.update!(always_update_pub_attrs(ai_pub))
+      end
+    end
+
+    def always_update_pub_attrs(pub)
+      {
+        activity_insight_postprint_status: pub.activity_insight_postprint_status
+      }
+    end
 
     def pub_attrs(pub)
       {

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -917,6 +917,8 @@ class ActivityInsightPublicationPostprint
   end
 
   def postprint_status
+    # NOTE: this field is misspelled as "ACCESIBLE" (one S) on the Activity Insight side,
+    # so the below misspelling is intentional.
     text_for('ACCESIBLE')
   end
 

--- a/app/importers/activity_insight_importer.rb
+++ b/app/importers/activity_insight_importer.rb
@@ -211,6 +211,7 @@ class ActivityInsightImporter
         publisher_name: pub.publisher,
         secondary_title: pub.secondary_title,
         status: pub.status,
+        activity_insight_postprint_status: pub.activity_insight_postprint_status,
         volume: pub.volume,
         issue: pub.issue,
         edition: pub.edition,
@@ -798,6 +799,16 @@ class ActivityInsightPublication
     text_for('RMD_ID')
   end
 
+  def postprints
+    parsed_publication.css('POST_FILE').map do |p|
+      ActivityInsightPublicationPostprint.new(p)
+    end
+  end
+
+  def activity_insight_postprint_status
+    postprints.first&.postprint_status
+  end
+
   private
 
     attr_reader :parsed_publication, :user
@@ -881,5 +892,23 @@ class ActivityInsightPublicationAuthor
 
     def for_external_person?
       activity_insight_user_id.blank?
+    end
+end
+
+class ActivityInsightPublicationPostprint
+  def initialize(parsed_postprint)
+    @parsed_postprint = parsed_postprint
+  end
+
+  def postprint_status
+    text_for('ACCESIBLE')
+  end
+
+  private
+
+    attr_reader :parsed_postprint
+
+    def text_for(element)
+      parsed_postprint.css(element).text.strip.presence
     end
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -22,6 +22,16 @@ class Publication < ApplicationRecord
     ]
   end
 
+  def self.postprint_statuses
+    [
+      'Already Openly Available',
+      'Cannot Deposit',
+      'Deposited to ScholarSphere',
+      'File provided was not a post-print',
+      'In Progress'
+    ]
+  end
+
   def self.open_access_statuses
     ['gold', 'hybrid', 'bronze', 'green', 'closed']
   end
@@ -66,6 +76,7 @@ class Publication < ApplicationRecord
   validates :publication_type, inclusion: { in: publication_types }
   validates :status, inclusion: { in: [PUBLISHED_STATUS, IN_PRESS_STATUS] }
   validates :open_access_status, inclusion: { in: open_access_statuses, allow_nil: true }
+  validates :activity_insight_postprint_status, inclusion: { in: postprint_statuses, allow_nil: true }
 
   validate :doi_format_is_valid
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -348,6 +348,7 @@ class Publication < ApplicationRecord
       field(:publisher_name)
       field(:publication_type)
       field(:status)
+      field(:activity_insight_postprint_status)
       field(:created_at) { read_only true }
       field(:updated_at) { read_only true }
       field(:updated_by_user_at) { read_only true }
@@ -403,6 +404,7 @@ class Publication < ApplicationRecord
         label 'DOI'
         pretty_value { %{<a href="#{value}" target="_blank">#{value}</a>}.html_safe if value }
       end
+      field(:activity_insight_postprint_status)
       field(:open_access_status)
       field(:open_access_button_last_checked_at)
       field(:unpaywall_last_checked_at)

--- a/db/migrate/20211117144654_add_ai_postprint_status_to_publication.rb
+++ b/db/migrate/20211117144654_add_ai_postprint_status_to_publication.rb
@@ -1,0 +1,5 @@
+class AddAiPostprintStatusToPublication < ActiveRecord::Migration[6.1]
+  def change
+    add_column :publications, :activity_insight_postprint_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_09_153954) do
+ActiveRecord::Schema.define(version: 2021_11_17_144654) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -460,6 +460,7 @@ ActiveRecord::Schema.define(version: 2021_11_09_153954) do
     t.boolean "exported_to_activity_insight"
     t.string "open_access_status"
     t.datetime "unpaywall_last_checked_at"
+    t.string "activity_insight_postprint_status"
     t.index "date_part('year'::text, published_on)", name: "index_publications_on_published_on_year"
     t.index ["doi"], name: "index_publications_on_doi"
     t.index ["duplicate_publication_group_id"], name: "index_publications_on_duplicate_publication_group_id"

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -991,6 +991,7 @@ describe ActivityInsightImporter do
                                     publisher_name: 'Existing Publisher',
                                     secondary_title: 'Existing Subtitle',
                                     status: 'In Press',
+                                    activity_insight_postprint_status: 'Cannot Deposit',
                                     volume: '111',
                                     issue: '222',
                                     edition: '333',
@@ -1018,7 +1019,7 @@ describe ActivityInsightImporter do
             expect { importer.call }.to change(Publication, :count).by 3
           end
 
-          it 'saves the correct data to the new publication records and does not update the existing record' do
+          it 'saves the correct data to the new publication records and only updates a subset of attributes on existing records' do
             importer.call
 
             p1 = PublicationImport.find_by(source: 'Activity Insight',
@@ -1055,6 +1056,7 @@ describe ActivityInsightImporter do
             expect(p2.publisher_name).to eq 'Existing Publisher'
             expect(p2.secondary_title).to eq 'Existing Subtitle'
             expect(p2.status).to eq 'In Press'
+            expect(p2.activity_insight_postprint_status).to eq 'In Progress'
             expect(p2.volume).to eq '111'
             expect(p2.issue).to eq '222'
             expect(p2.edition).to eq '333'
@@ -2584,6 +2586,7 @@ describe ActivityInsightImporter do
                                       publisher_name: 'Existing Publisher',
                                       secondary_title: 'Existing Subtitle',
                                       status: 'In Press',
+                                      activity_insight_postprint_status: 'Cannot Deposit',
                                       volume: '111',
                                       issue: '222',
                                       edition: '333',
@@ -2611,7 +2614,7 @@ describe ActivityInsightImporter do
               expect { importer.call }.to change(Publication, :count).by 3
             end
 
-            it 'saves the correct data to the new publication records and does not update the existing record' do
+            it 'saves the correct data to the new publication records and only updates a subset of attributes on existing records' do
               importer.call
 
               p1 = PublicationImport.find_by(source: 'Activity Insight',
@@ -2629,6 +2632,7 @@ describe ActivityInsightImporter do
               expect(p1.publisher_name).to eq 'Test Publisher 1'
               expect(p1.secondary_title).to eq 'Subtitle 1'
               expect(p1.status).to eq 'Published'
+              expect(p2.activity_insight_postprint_status).to eq 'In Progress'
               expect(p1.activity_insight_postprint_status).to eq nil
               expect(p1.volume).to eq '9'
               expect(p1.issue).to eq '5'
@@ -4155,6 +4159,7 @@ describe ActivityInsightImporter do
                                       publisher_name: 'Existing Publisher',
                                       secondary_title: 'Existing Subtitle',
                                       status: 'In Press',
+                                      activity_insight_postprint_status: 'Cannot Deposit',
                                       volume: '111',
                                       issue: '222',
                                       edition: '333',
@@ -4182,7 +4187,7 @@ describe ActivityInsightImporter do
               expect { importer.call }.to change(Publication, :count).by 3
             end
 
-            it 'saves the correct data to the new publication records and does not update the existing record' do
+            it 'saves the correct data to the new publication records and only updates a subset of attributes on existing records' do
               importer.call
 
               p1 = PublicationImport.find_by(source: 'Activity Insight',
@@ -4200,6 +4205,7 @@ describe ActivityInsightImporter do
               expect(p1.publisher_name).to eq 'Test Publisher 1'
               expect(p1.secondary_title).to eq 'Subtitle 1'
               expect(p1.status).to eq 'Published'
+              expect(p2.activity_insight_postprint_status).to eq 'In Progress'
               expect(p1.activity_insight_postprint_status).to eq nil
               expect(p1.volume).to eq '9'
               expect(p1.issue).to eq '5'

--- a/spec/component/importers/activity_insight_importer_spec.rb
+++ b/spec/component/importers/activity_insight_importer_spec.rb
@@ -776,6 +776,7 @@ describe ActivityInsightImporter do
           expect(p1.publisher_name).to eq 'Test Publisher 1'
           expect(p1.secondary_title).to eq 'Subtitle 1'
           expect(p1.status).to eq 'Published'
+          expect(p1.activity_insight_postprint_status).to eq nil
           expect(p1.volume).to eq '9'
           expect(p1.issue).to eq '5'
           expect(p1.edition).to eq '10'
@@ -794,6 +795,7 @@ describe ActivityInsightImporter do
           expect(p2.publisher_name).to eq nil
           expect(p2.secondary_title).to eq 'Second Pub Subtitle'
           expect(p2.status).to eq 'Published'
+          expect(p2.activity_insight_postprint_status).to eq 'In Progress'
           expect(p2.volume).to eq '7'
           expect(p2.issue).to eq nil
           expect(p2.edition).to eq nil
@@ -813,6 +815,7 @@ describe ActivityInsightImporter do
           expect(p3.publisher_name).to eq 'Some Other Publisher'
           expect(p3.secondary_title).to eq nil
           expect(p3.status).to eq 'Published'
+          expect(p3.activity_insight_postprint_status).to eq 'Deposited to ScholarSphere'
           expect(p3.volume).to eq '17'
           expect(p3.issue).to eq '8'
           expect(p3.edition).to eq '4'
@@ -832,6 +835,7 @@ describe ActivityInsightImporter do
           expect(p4.publisher_name).to eq 'Test Publisher 1'
           expect(p4.secondary_title).to eq 'Subtitle 2'
           expect(p4.status).to eq 'In Press'
+          expect(p4.activity_insight_postprint_status).to eq nil
           expect(p4.volume).to eq '10'
           expect(p4.issue).to eq '2'
           expect(p4.edition).to eq '15'
@@ -1032,6 +1036,7 @@ describe ActivityInsightImporter do
             expect(p1.publisher_name).to eq 'Test Publisher 1'
             expect(p1.secondary_title).to eq 'Subtitle 1'
             expect(p1.status).to eq 'Published'
+            expect(p1.activity_insight_postprint_status).to eq nil
             expect(p1.volume).to eq '9'
             expect(p1.issue).to eq '5'
             expect(p1.edition).to eq '10'
@@ -1069,6 +1074,7 @@ describe ActivityInsightImporter do
             expect(p3.publisher_name).to eq 'Some Other Publisher'
             expect(p3.secondary_title).to eq nil
             expect(p3.status).to eq 'Published'
+            expect(p3.activity_insight_postprint_status).to eq 'Deposited to ScholarSphere'
             expect(p3.volume).to eq '17'
             expect(p3.issue).to eq '8'
             expect(p3.edition).to eq '4'
@@ -1088,6 +1094,7 @@ describe ActivityInsightImporter do
             expect(p4.publisher_name).to eq 'Test Publisher 1'
             expect(p4.secondary_title).to eq 'Subtitle 2'
             expect(p4.status).to eq 'In Press'
+            expect(p4.activity_insight_postprint_status).to eq nil
             expect(p4.volume).to eq '10'
             expect(p4.issue).to eq '2'
             expect(p4.edition).to eq '15'
@@ -1320,6 +1327,7 @@ describe ActivityInsightImporter do
             expect(p1.publisher_name).to eq 'Test Publisher 1'
             expect(p1.secondary_title).to eq 'Subtitle 1'
             expect(p1.status).to eq 'Published'
+            expect(p1.activity_insight_postprint_status).to eq nil
             expect(p1.volume).to eq '9'
             expect(p1.issue).to eq '5'
             expect(p1.edition).to eq '10'
@@ -1338,6 +1346,7 @@ describe ActivityInsightImporter do
             expect(p2.publisher_name).to eq nil
             expect(p2.secondary_title).to eq 'Second Pub Subtitle'
             expect(p2.status).to eq 'Published'
+            expect(p2.activity_insight_postprint_status).to eq 'In Progress'
             expect(p2.volume).to eq '7'
             expect(p2.issue).to eq nil
             expect(p2.edition).to eq nil
@@ -1357,6 +1366,7 @@ describe ActivityInsightImporter do
             expect(p3.publisher_name).to eq 'Some Other Publisher'
             expect(p3.secondary_title).to eq nil
             expect(p3.status).to eq 'Published'
+            expect(p3.activity_insight_postprint_status).to eq 'Deposited to ScholarSphere'
             expect(p3.volume).to eq '17'
             expect(p3.issue).to eq '8'
             expect(p3.edition).to eq '4'
@@ -1376,6 +1386,7 @@ describe ActivityInsightImporter do
             expect(p4.publisher_name).to eq 'Test Publisher 1'
             expect(p4.secondary_title).to eq 'Subtitle 2'
             expect(p4.status).to eq 'In Press'
+            expect(p4.activity_insight_postprint_status).to eq nil
             expect(p4.volume).to eq '10'
             expect(p4.issue).to eq '2'
             expect(p4.edition).to eq '15'
@@ -2358,6 +2369,7 @@ describe ActivityInsightImporter do
             expect(p1.publisher_name).to eq 'Test Publisher 1'
             expect(p1.secondary_title).to eq 'Subtitle 1'
             expect(p1.status).to eq 'Published'
+            expect(p1.activity_insight_postprint_status).to eq nil
             expect(p1.volume).to eq '9'
             expect(p1.issue).to eq '5'
             expect(p1.edition).to eq '10'
@@ -2376,6 +2388,7 @@ describe ActivityInsightImporter do
             expect(p2.publisher_name).to eq nil
             expect(p2.secondary_title).to eq 'Second Pub Subtitle'
             expect(p2.status).to eq 'Published'
+            expect(p2.activity_insight_postprint_status).to eq 'In Progress'
             expect(p2.volume).to eq '7'
             expect(p2.issue).to eq nil
             expect(p2.edition).to eq nil
@@ -2395,6 +2408,7 @@ describe ActivityInsightImporter do
             expect(p3.publisher_name).to eq 'Some Other Publisher'
             expect(p3.secondary_title).to eq nil
             expect(p3.status).to eq 'Published'
+            expect(p3.activity_insight_postprint_status).to eq 'Deposited to ScholarSphere'
             expect(p3.volume).to eq '17'
             expect(p3.issue).to eq '8'
             expect(p3.edition).to eq '4'
@@ -2414,6 +2428,7 @@ describe ActivityInsightImporter do
             expect(p4.publisher_name).to eq 'Test Publisher 1'
             expect(p4.secondary_title).to eq 'Subtitle 2'
             expect(p4.status).to eq 'In Press'
+            expect(p4.activity_insight_postprint_status).to eq nil
             expect(p4.volume).to eq '10'
             expect(p4.issue).to eq '2'
             expect(p4.edition).to eq '15'
@@ -2614,6 +2629,7 @@ describe ActivityInsightImporter do
               expect(p1.publisher_name).to eq 'Test Publisher 1'
               expect(p1.secondary_title).to eq 'Subtitle 1'
               expect(p1.status).to eq 'Published'
+              expect(p1.activity_insight_postprint_status).to eq nil
               expect(p1.volume).to eq '9'
               expect(p1.issue).to eq '5'
               expect(p1.edition).to eq '10'
@@ -2651,6 +2667,7 @@ describe ActivityInsightImporter do
               expect(p3.publisher_name).to eq 'Some Other Publisher'
               expect(p3.secondary_title).to eq nil
               expect(p3.status).to eq 'Published'
+              expect(p3.activity_insight_postprint_status).to eq 'Deposited to ScholarSphere'
               expect(p3.volume).to eq '17'
               expect(p3.issue).to eq '8'
               expect(p3.edition).to eq '4'
@@ -2670,6 +2687,7 @@ describe ActivityInsightImporter do
               expect(p4.publisher_name).to eq 'Test Publisher 1'
               expect(p4.secondary_title).to eq 'Subtitle 2'
               expect(p4.status).to eq 'In Press'
+              expect(p4.activity_insight_postprint_status).to eq nil
               expect(p4.volume).to eq '10'
               expect(p4.issue).to eq '2'
               expect(p4.edition).to eq '15'
@@ -2903,6 +2921,7 @@ describe ActivityInsightImporter do
               expect(p1.publisher_name).to eq 'Test Publisher 1'
               expect(p1.secondary_title).to eq 'Subtitle 1'
               expect(p1.status).to eq 'Published'
+              expect(p1.activity_insight_postprint_status).to eq nil
               expect(p1.volume).to eq '9'
               expect(p1.issue).to eq '5'
               expect(p1.edition).to eq '10'
@@ -2921,6 +2940,7 @@ describe ActivityInsightImporter do
               expect(p2.publisher_name).to eq nil
               expect(p2.secondary_title).to eq 'Second Pub Subtitle'
               expect(p2.status).to eq 'Published'
+              expect(p2.activity_insight_postprint_status).to eq 'In Progress'
               expect(p2.volume).to eq '7'
               expect(p2.issue).to eq nil
               expect(p2.edition).to eq nil
@@ -2940,6 +2960,7 @@ describe ActivityInsightImporter do
               expect(p3.publisher_name).to eq 'Some Other Publisher'
               expect(p3.secondary_title).to eq nil
               expect(p3.status).to eq 'Published'
+              expect(p3.activity_insight_postprint_status).to eq 'Deposited to ScholarSphere'
               expect(p3.volume).to eq '17'
               expect(p3.issue).to eq '8'
               expect(p3.edition).to eq '4'
@@ -2959,6 +2980,7 @@ describe ActivityInsightImporter do
               expect(p4.publisher_name).to eq 'Test Publisher 1'
               expect(p4.secondary_title).to eq 'Subtitle 2'
               expect(p4.status).to eq 'In Press'
+              expect(p4.activity_insight_postprint_status).to eq nil
               expect(p4.volume).to eq '10'
               expect(p4.issue).to eq '2'
               expect(p4.edition).to eq '15'
@@ -3918,6 +3940,7 @@ describe ActivityInsightImporter do
             expect(p1.publisher_name).to eq 'Test Publisher 1'
             expect(p1.secondary_title).to eq 'Subtitle 1'
             expect(p1.status).to eq 'Published'
+            expect(p1.activity_insight_postprint_status).to eq nil
             expect(p1.volume).to eq '9'
             expect(p1.issue).to eq '5'
             expect(p1.edition).to eq '10'
@@ -3936,6 +3959,7 @@ describe ActivityInsightImporter do
             expect(p2.publisher_name).to eq nil
             expect(p2.secondary_title).to eq 'Second Pub Subtitle'
             expect(p2.status).to eq 'Published'
+            expect(p2.activity_insight_postprint_status).to eq 'In Progress'
             expect(p2.volume).to eq '7'
             expect(p2.issue).to eq nil
             expect(p2.edition).to eq nil
@@ -3955,6 +3979,7 @@ describe ActivityInsightImporter do
             expect(p3.publisher_name).to eq 'Some Other Publisher'
             expect(p3.secondary_title).to eq nil
             expect(p3.status).to eq 'Published'
+            expect(p3.activity_insight_postprint_status).to eq 'Deposited to ScholarSphere'
             expect(p3.volume).to eq '17'
             expect(p3.issue).to eq '8'
             expect(p3.edition).to eq '4'
@@ -3974,6 +3999,7 @@ describe ActivityInsightImporter do
             expect(p4.publisher_name).to eq 'Test Publisher 1'
             expect(p4.secondary_title).to eq 'Subtitle 2'
             expect(p4.status).to eq 'In Press'
+            expect(p4.activity_insight_postprint_status).to eq nil
             expect(p4.volume).to eq '10'
             expect(p4.issue).to eq '2'
             expect(p4.edition).to eq '15'
@@ -4174,6 +4200,7 @@ describe ActivityInsightImporter do
               expect(p1.publisher_name).to eq 'Test Publisher 1'
               expect(p1.secondary_title).to eq 'Subtitle 1'
               expect(p1.status).to eq 'Published'
+              expect(p1.activity_insight_postprint_status).to eq nil
               expect(p1.volume).to eq '9'
               expect(p1.issue).to eq '5'
               expect(p1.edition).to eq '10'
@@ -4211,6 +4238,7 @@ describe ActivityInsightImporter do
               expect(p3.publisher_name).to eq 'Some Other Publisher'
               expect(p3.secondary_title).to eq nil
               expect(p3.status).to eq 'Published'
+              expect(p3.activity_insight_postprint_status).to eq 'Deposited to ScholarSphere'
               expect(p3.volume).to eq '17'
               expect(p3.issue).to eq '8'
               expect(p3.edition).to eq '4'
@@ -4230,6 +4258,7 @@ describe ActivityInsightImporter do
               expect(p4.publisher_name).to eq 'Test Publisher 1'
               expect(p4.secondary_title).to eq 'Subtitle 2'
               expect(p4.status).to eq 'In Press'
+              expect(p4.activity_insight_postprint_status).to eq nil
               expect(p4.volume).to eq '10'
               expect(p4.issue).to eq '2'
               expect(p4.edition).to eq '15'
@@ -4462,6 +4491,7 @@ describe ActivityInsightImporter do
               expect(p1.publisher_name).to eq 'Test Publisher 1'
               expect(p1.secondary_title).to eq 'Subtitle 1'
               expect(p1.status).to eq 'Published'
+              expect(p1.activity_insight_postprint_status).to eq nil
               expect(p1.volume).to eq '9'
               expect(p1.issue).to eq '5'
               expect(p1.edition).to eq '10'
@@ -4480,6 +4510,7 @@ describe ActivityInsightImporter do
               expect(p2.publisher_name).to eq nil
               expect(p2.secondary_title).to eq 'Second Pub Subtitle'
               expect(p2.status).to eq 'Published'
+              expect(p2.activity_insight_postprint_status).to eq 'In Progress'
               expect(p2.volume).to eq '7'
               expect(p2.issue).to eq nil
               expect(p2.edition).to eq nil
@@ -4499,6 +4530,7 @@ describe ActivityInsightImporter do
               expect(p3.publisher_name).to eq 'Some Other Publisher'
               expect(p3.secondary_title).to eq nil
               expect(p3.status).to eq 'Published'
+              expect(p3.activity_insight_postprint_status).to eq 'Deposited to ScholarSphere'
               expect(p3.volume).to eq '17'
               expect(p3.issue).to eq '8'
               expect(p3.edition).to eq '4'
@@ -4518,6 +4550,7 @@ describe ActivityInsightImporter do
               expect(p4.publisher_name).to eq 'Test Publisher 1'
               expect(p4.secondary_title).to eq 'Subtitle 2'
               expect(p4.status).to eq 'In Press'
+              expect(p4.activity_insight_postprint_status).to eq nil
               expect(p4.volume).to eq '10'
               expect(p4.issue).to eq '2'
               expect(p4.edition).to eq '15'

--- a/spec/component/models/publication_spec.rb
+++ b/spec/component/models/publication_spec.rb
@@ -33,6 +33,7 @@ describe 'the publications table', type: :model do
   it { is_expected.to have_db_column(:journal_id).of_type(:integer) }
   it { is_expected.to have_db_column(:exported_to_activity_insight).of_type(:boolean) }
   it { is_expected.to have_db_column(:open_access_status).of_type(:string) }
+  it { is_expected.to have_db_column(:activity_insight_postprint_status).of_type(:string) }
 
   it { is_expected.to have_db_foreign_key(:duplicate_publication_group_id) }
   it { is_expected.to have_db_foreign_key(:journal_id) }
@@ -56,6 +57,7 @@ describe Publication, type: :model do
     it { is_expected.to validate_inclusion_of(:publication_type).in_array(described_class.publication_types) }
     it { is_expected.to validate_inclusion_of(:status).in_array([Publication::PUBLISHED_STATUS, Publication::IN_PRESS_STATUS]) }
     it { is_expected.to validate_inclusion_of(:open_access_status).in_array(described_class.open_access_statuses).allow_nil }
+    it { is_expected.to validate_inclusion_of(:activity_insight_postprint_status).in_array(described_class.postprint_statuses).allow_nil }
 
     describe 'validating DOI format' do
       let(:pub) { build :publication, doi: doi }
@@ -254,6 +256,16 @@ describe Publication, type: :model do
   describe '.open_access_statuses' do
     it 'returns the list of valid values for open access status' do
       expect(described_class.open_access_statuses).to eq ['gold', 'hybrid', 'bronze', 'green', 'closed']
+    end
+  end
+
+  describe '.postprint_statuses' do
+    it 'returns the list of valid values for postprint status' do
+      expect(described_class.postprint_statuses).to eq ['Already Openly Available',
+                                                        'Cannot Deposit',
+                                                        'Deposited to ScholarSphere',
+                                                        'File provided was not a post-print',
+                                                        'In Progress']
     end
   end
 

--- a/spec/fixtures/activity_insight_user_abc123.xml
+++ b/spec/fixtures/activity_insight_user_abc123.xml
@@ -406,6 +406,7 @@
       </INTELLCONT_FILE>
       <POST_FILE id="171620739080">
         <DOC/>
+        <ACCESIBLE>In Progress</ACCESIBLE>
       </POST_FILE>
       <DTM_EXPSUB/>
       <DTD_EXPSUB/>
@@ -561,6 +562,14 @@
       <CITATION_END/>
       <DESC_INTERNATIONAL/>
       <RESEARCH_PROJECT/>
+      <POST_FILE id="171620739081">
+        <DOC/>
+        <ACCESIBLE>Deposited to ScholarSphere</ACCESIBLE>
+      </POST_FILE>
+      <POST_FILE id="171620739082">
+        <DOC/>
+        <ACCESIBLE>In Progress</ACCESIBLE>
+      </POST_FILE>
       <DTM_EXPSUB/>
       <DTD_EXPSUB/>
       <DTY_EXPSUB/>


### PR DESCRIPTION
Closes #189.

We import the `ACCESIBLE` field from publication data coming from Activity Insight, and store it on the publication model in RMD as `activity_insight_postprint_status`.

This new field is now filterable on the publication list page in Rails Admin.