### PR TITLE
Allow admins to create authorships by selecting a user and publication

### DIFF
--- a/app/models/authorship.rb
+++ b/app/models/authorship.rb
@@ -39,7 +39,9 @@ class Authorship < ApplicationRecord
   scope :claimed_and_unconfirmed, -> { where(confirmed: false, claimed_by_user: true) }
 
   def description
-    "##{id} (#{user.name} - #{publication.title})"
+    if persisted?
+      "##{id} (#{user.name} - #{publication.title})"
+    end
   end
 
   def record_open_access_notification
@@ -64,6 +66,13 @@ class Authorship < ApplicationRecord
       field(:publication)
       field(:confirmed)
       field(:claimed_by_user)
+    end
+
+    create do
+      field(:user)
+      field(:publication)
+      field(:author_number)
+      field(:confirmed)
     end
 
     edit do

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -67,7 +67,8 @@ RailsAdmin.config do |config|
             :Authorship]
     end
     new do
-      only [:Publication,
+      only [:Authorship,
+            :Publication,
             :User,
             :APIToken,
             :ExternalPublicationWaiver,

--- a/spec/component/models/authorship_spec.rb
+++ b/spec/component/models/authorship_spec.rb
@@ -103,10 +103,21 @@ describe Authorship, type: :model do
   describe '#description' do
     let(:u) { create :user, first_name: 'Bob', last_name: 'Testerson' }
     let(:p) { create :publication, title: 'Example Pub' }
-    let(:a) { create :authorship, user: u, publication: p }
 
-    it 'returns a string describing the record' do
-      expect(a.description).to eq "##{a.id} (Bob Testerson - Example Pub)"
+    context 'when the authorship is not persisted' do
+      let(:a) { described_class.new }
+
+      it 'returns nil' do
+        expect(a.description).to be_nil
+      end
+    end
+
+    context 'when the authorship is persisted' do
+      let(:a) { create :authorship, user: u, publication: p }
+
+      it 'returns a string describing the record' do
+        expect(a.description).to eq "##{a.id} (Bob Testerson - Example Pub)"
+      end
     end
   end
 

--- a/spec/integration/admin/authorships/create_spec.rb
+++ b/spec/integration/admin/authorships/create_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'integration/integration_spec_helper'
+require 'integration/admin/shared_examples_for_admin_page'
+
+describe 'Creating an authorship', type: :feature do
+  let!(:user) { create :user, first_name: 'Emily', last_name: 'Researcher' }
+  let!(:pub) { create :publication, title: 'New Scientific Research' }
+
+  context 'when the current user is an admin' do
+    before do
+      authenticate_admin_user
+      visit rails_admin.new_path(model_name: :authorship)
+    end
+
+    describe 'visiting the form to create a new authorship' do
+      it_behaves_like 'a page with the admin layout'
+      it 'show the correct content' do
+        expect(page).to have_content 'New Authorship'
+      end
+    end
+
+    describe 'submitting the form to create a new authorship', js: true do
+      before do
+        within '#authorship_user_id_field' do
+          find('.dropdown-toggle').click
+        end
+        find('a', text: 'Emily Researcher').click
+        within '#authorship_publication_id_field' do
+          find('.dropdown-toggle').click
+        end
+        find('a', text: 'New Scientific Research').click
+        fill_in 'Author number', with: 2
+        check 'Confirmed'
+
+        click_button 'Save'
+      end
+
+      it 'creates a new authorship record in the database with the provided data' do
+        a = Authorship.find_by(user: user, publication: pub)
+
+        expect(a.author_number).to eq 2
+        expect(a.confirmed).to eq true
+      end
+    end
+  end
+
+  context 'when the current user is not an admin' do
+    before { authenticate_user }
+
+    it 'redirects back to the home page with an error message' do
+      visit rails_admin.new_path(model_name: :authorship)
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content I18n.t('admin.authorization.not_authorized')
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/psu-stewardship/researcher-metadata/issues/365

This adds the 'new' action for Authorships in the RailsAdmin UI, allowing admins to create new authorship records by searching/selecting users and publications.