### PR TITLE
Refactor `User.from_omniauth` and `NewDeputyAssignmentForm` to use a common PsuIdentity service object

### DIFF
--- a/app/services/psu_identity_user_service.rb
+++ b/app/services/psu_identity_user_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class PsuIdentityUserService
+  class IdentityServiceError < StandardError; end
+
+  class << self
+    def find_or_initialize_user(webaccess_id:)
+      User.find_by(webaccess_id: webaccess_id) ||
+        initialize_user_from_psu_identity(webaccess_id)
+    end
+
+    private
+
+      def initialize_user_from_psu_identity(webaccess_id)
+        identity = query_psu_identity(webaccess_id)
+        return nil if identity.blank?
+
+        User.new(
+          webaccess_id: webaccess_id,
+          first_name: (identity.preferred_given_name.presence || identity.given_name),
+          last_name: (identity.preferred_family_name.presence || identity.family_name),
+          psu_identity: identity,
+          psu_identity_updated_at: Time.zone.now
+        )
+      end
+
+      def query_psu_identity(webaccess_id)
+        PsuIdentity::SearchService::Client.new.userid(webaccess_id)
+      rescue URI::InvalidURIError
+        nil
+      rescue StandardError
+        raise IdentityServiceError
+      end
+  end
+end

--- a/spec/component/models/user_spec.rb
+++ b/spec/component/models/user_spec.rb
@@ -1656,32 +1656,6 @@ describe User, type: :model do
     end
   end
 
-  describe '#attributes_from_psu_identity', :vcr do
-    before { user.attributes_from_psu_identity }
-
-    context 'when identity data is present' do
-      let(:user) { create(:user, webaccess_id: 'agw13') }
-
-      it "sets the user's attributes using data from Penn State" do
-        expect(user.first_name).to eq('Adam')
-        expect(user.last_name).to eq('Wead')
-        expect(user.psu_identity).not_to be_nil
-        expect(user.psu_identity_updated_at).to be_within(1.minute).of(Time.zone.now)
-      end
-    end
-
-    context 'when identity data is not present' do
-      let(:user) { create(:user, webaccess_id: 'idonotexist') }
-
-      it "does not change the user's attributes" do
-        expect(user.first_name).to eq(user.first_name)
-        expect(user.last_name).to eq(user.last_name)
-        expect(user.psu_identity).to be_nil
-        expect(user.psu_identity_updated_at).to be_nil
-      end
-    end
-  end
-
   describe '#active?' do
     subject { user }
 

--- a/spec/component/services/psu_identity_user_service_spec.rb
+++ b/spec/component/services/psu_identity_user_service_spec.rb
@@ -3,10 +3,13 @@
 require 'component/component_spec_helper'
 
 describe PsuIdentityUserService do
+  # Note this spec uses VCR to mock HTTP requests to the actual PSU identity
+  # server. If you change this value, you will will invalidate the VCR
+  # cassettes and send new requests.
+  let(:webaccess_id) { 'abc123' }
+
   describe '.find_or_initialize_user' do
     subject(:call) { described_class.find_or_initialize_user(webaccess_id: webaccess_id) }
-
-    let(:webaccess_id) { 'abc123' }
 
     context 'when the User exists in the database' do
       let!(:user) { create :user, :with_psu_identity, webaccess_id: webaccess_id }

--- a/spec/component/services/psu_identity_user_service_spec.rb
+++ b/spec/component/services/psu_identity_user_service_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'component/component_spec_helper'
+
+describe PsuIdentityUserService do
+  describe '.find_or_initialize_user' do
+    subject(:call) { described_class.find_or_initialize_user(webaccess_id: webaccess_id) }
+
+    let(:webaccess_id) { 'abc123' }
+
+    context 'when the User exists in the database' do
+      let!(:user) { create :user, :with_psu_identity, webaccess_id: webaccess_id }
+
+      it 'returns the User' do
+        expect(call).to eq user
+      end
+    end
+
+    context 'when no User exists in the database' do
+      context 'when all is well with PsuIdentity' do
+        let(:user) { call }
+
+        context 'when the user in PsuIdentity has no preferred names', vcr: true do
+          it 'returns a User initialized with data from PsuIdentity' do
+            # Note this relies on an edited VCR cassette
+            expect(user).not_to be_persisted
+            expect(user.webaccess_id).to eq webaccess_id
+            expect(user.first_name).to eq 'Firstname'
+            expect(user.last_name).to eq 'Lastname'
+            expect(user.psu_identity).to be_an_instance_of(PsuIdentity::SearchService::Person)
+            expect(user.psu_identity_updated_at).to be_within(2.seconds).of(Time.zone.now)
+          end
+        end
+
+        context 'when the user in PsuIdentity has preferred names', vcr: true do
+          it 'returns a User initialized with data from PsuIdentity' do
+            # Note this relies on an edited VCR cassette
+            expect(user).not_to be_persisted
+            expect(user.webaccess_id).to eq webaccess_id
+            expect(user.first_name).to eq 'PreferredFirstname'
+            expect(user.last_name).to eq 'PreferredLastname'
+            expect(user.psu_identity).to be_an_instance_of(PsuIdentity::SearchService::Person)
+            expect(user.psu_identity_updated_at).to be_within(2.seconds).of(Time.zone.now)
+          end
+        end
+
+        context 'when there are no users found', vcr: true do
+          it 'returns nil' do
+            expect(user).to be_nil
+          end
+        end
+      end
+
+      context 'when PsuIdentity raises an error' do
+        let(:mock_psu_identity_client) { instance_spy 'PsuIdentity::SearchService::Client' }
+
+        before do
+          allow(PsuIdentity::SearchService::Client).to receive(:new).and_return(mock_psu_identity_client)
+          allow(mock_psu_identity_client).to receive(:userid).and_raise(error_to_raise)
+        end
+
+        context 'when PsuIdentity raises URI::InvalidURIError' do
+          let(:error_to_raise) { URI::InvalidURIError }
+
+          it 'returns nil' do
+            user = call
+            expect(user).to be_nil
+            expect(mock_psu_identity_client).to have_received(:userid).with(webaccess_id) # sanity
+          end
+        end
+
+        context 'when PsuIdentity raises Timeout::Error' do
+          let(:error_to_raise) { Timeout::Error }
+
+          specify do
+            expect { call }.to raise_error(described_class::IdentityServiceError)
+          end
+        end
+
+        context 'when PsuIdentity raises StandardError' do
+          let(:error_to_raise) { StandardError }
+
+          specify do
+            expect { call }.to raise_error(described_class::IdentityServiceError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/PsuIdentityUserService/_find_or_initialize_user/when_no_User_exists_in_the_database/when_all_is_well_with_PsuIdentity/when_the_user_in_PsuIdentity_has_no_preferred_names/returns_a_User_initialized_with_data_from_PsuIdentity.yml
+++ b/spec/fixtures/vcr_cassettes/PsuIdentityUserService/_find_or_initialize_user/when_no_User_exists_in_the_database/when_all_is_well_with_PsuIdentity/when_the_user_in_PsuIdentity_has_no_preferred_names/returns_a_User_initialized_with_data_from_PsuIdentity.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people/userid/abc123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 18 Nov 2021 18:13:26 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '251'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=JHBfFhotvO8CERoEJdFqzUt9whGvfV4EwWjKezPE.search-service-77488f987b-hfzhk;
+        path=/search-service
+      X-Request-Id:
+      - db95a27ffcb5082168cccd0d2da8305e
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - b2f4d0eb-2915-459d-ac25-86d94c8188ea
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"userid":"abc123","cprid":"7489945","givenName":"Firstname","familyName":"Lastname","active":true,"confHold":false,"serviceAccount":false,"affiliation":["MEMBER"],"displayName":"Firstname
+        Lastname","link":{"href":"https://dev.apps.psu.edu/cpr/resources/7489945"}}'
+  recorded_at: Thu, 18 Nov 2021 18:13:26 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/PsuIdentityUserService/_find_or_initialize_user/when_no_User_exists_in_the_database/when_all_is_well_with_PsuIdentity/when_the_user_in_PsuIdentity_has_preferred_names/returns_a_User_initialized_with_data_from_PsuIdentity.yml
+++ b/spec/fixtures/vcr_cassettes/PsuIdentityUserService/_find_or_initialize_user/when_no_User_exists_in_the_database/when_all_is_well_with_PsuIdentity/when_the_user_in_PsuIdentity_has_preferred_names/returns_a_User_initialized_with_data_from_PsuIdentity.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people/userid/abc123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 18 Nov 2021 18:24:48 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '357'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=Rtqvxp9Iv0f8vhN_6mhpT9_s4IVCg_VLaEC7vJ19.search-service-77488f987b-hfzhk;
+        path=/search-service
+      X-Request-Id:
+      - e55fdb971b52b5de87c467d1a17f8458
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - 2e489ad3-7452-4f71-9e48-2f10c8890b71
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"userid":"abc123","cprid":"2784093","givenName":"Firstname","middleName":"Garner","familyName":"Lastname","preferredGivenName":"PreferredFirstname","preferredFamilyName":"PreferredLastname","active":true,"confHold":false,"universityEmail":"agw13@psu.edu","serviceAccount":false,"affiliation":["STAFF"],"displayName":"PreferredFirstname
+        PreferredLastname","link":{"href":"https://dev.apps.psu.edu/cpr/resources/2784093"}}'
+  recorded_at: Thu, 18 Nov 2021 18:24:48 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/PsuIdentityUserService/_find_or_initialize_user/when_no_User_exists_in_the_database/when_all_is_well_with_PsuIdentity/when_there_are_no_users_found/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/PsuIdentityUserService/_find_or_initialize_user/when_no_User_exists_in_the_database/when_all_is_well_with_PsuIdentity/when_there_are_no_users_found/returns_nil.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people/userid/abc123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Thu, 18 Nov 2021 18:46:58 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '119'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=FSNhyfa6DQAfFDm_wudx51rROPkvYeNXZrGhQ61l.search-service-77488f987b-86bbc;
+        path=/search-service
+      X-Request-Id:
+      - 0d2ee1490704049ff0b366dbde8a966f
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - 98ddbc30-65e2-411c-b124-e96663afb52c
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"status":{"code":404,"message":"NOT_FOUND"},"errorMessage":["No person
+        matched the input userid: abc123"],"link":null}'
+  recorded_at: Thu, 18 Nov 2021 18:46:58 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/User/_psu_identity/when_identity_data_is_present/2_37_1_1.yml
+++ b/spec/fixtures/vcr_cassettes/User/_psu_identity/when_identity_data_is_present/2_37_1_1.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people/userid/agw13
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Nov 2021 17:56:17 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '357'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=kSp6h-aeF_pTIvnD2HGXIH_JbuJAO5Haktx1Lrrs.search-service-588df69bd9-2c7hk;
+        path=/search-service
+      X-Request-Id:
+      - 5c74f5fde734d5e54c17df569110c821
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - ae3593b4-cdd1-4711-ac68-33ec4b3c997f
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"userid":"agw13","cprid":"2784093","givenName":"Adam","middleName":"Garner","familyName":"Wead","preferredGivenName":"Adam","preferredFamilyName":"Wead","active":true,"confHold":false,"universityEmail":"agw13@psu.edu","serviceAccount":false,"affiliation":["STAFF"],"displayName":"Adam
+        Wead","link":{"href":"https://dev.apps.psu.edu/cpr/resources/2784093"}}'
+  recorded_at: Tue, 23 Nov 2021 17:56:17 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/User/_psu_identity/when_identity_data_is_present/given_name/2_37_1_3_1.yml
+++ b/spec/fixtures/vcr_cassettes/User/_psu_identity/when_identity_data_is_present/given_name/2_37_1_3_1.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people/userid/agw13
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Nov 2021 17:56:18 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '357'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=acTJQy310kf8tewU3WP_j8iMZLZaFedsXW0eKhqz.search-service-588df69bd9-vjs9f;
+        path=/search-service
+      X-Request-Id:
+      - b765109517ee4b52f72e762e9dd1f2fd
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - 4e6884e2-51d7-4701-948b-8a0e37d19c16
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"userid":"agw13","cprid":"2784093","givenName":"Adam","middleName":"Garner","familyName":"Wead","preferredGivenName":"Adam","preferredFamilyName":"Wead","active":true,"confHold":false,"universityEmail":"agw13@psu.edu","serviceAccount":false,"affiliation":["STAFF"],"displayName":"Adam
+        Wead","link":{"href":"https://dev.apps.psu.edu/cpr/resources/2784093"}}'
+  recorded_at: Tue, 23 Nov 2021 17:56:18 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/User/_psu_identity/when_identity_data_is_present/surname/2_37_1_2_1.yml
+++ b/spec/fixtures/vcr_cassettes/User/_psu_identity/when_identity_data_is_present/surname/2_37_1_2_1.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people/userid/agw13
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Nov 2021 17:56:18 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '357'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=_ZPj63MOO8HwMwUCatSbM2jgyvwXshLID27GY5nW.search-service-588df69bd9-vjs9f;
+        path=/search-service
+      X-Request-Id:
+      - ff6b4f4e15a92a750d15f5cd4efd2010
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - 9cda528c-209e-4e83-945e-f2db482ffc27
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"userid":"agw13","cprid":"2784093","givenName":"Adam","middleName":"Garner","familyName":"Wead","preferredGivenName":"Adam","preferredFamilyName":"Wead","active":true,"confHold":false,"universityEmail":"agw13@psu.edu","serviceAccount":false,"affiliation":["STAFF"],"displayName":"Adam
+        Wead","link":{"href":"https://dev.apps.psu.edu/cpr/resources/2784093"}}'
+  recorded_at: Tue, 23 Nov 2021 17:56:18 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/User/_psu_identity/when_identity_data_is_present/user_id/2_37_1_4_1.yml
+++ b/spec/fixtures/vcr_cassettes/User/_psu_identity/when_identity_data_is_present/user_id/2_37_1_4_1.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people/userid/agw13
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Nov 2021 17:56:18 GMT
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Content-Length:
+      - '357'
+      Connection:
+      - keep-alive
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      Set-Cookie:
+      - JSESSIONID=HP4y51EwA3WIfheEw5_H_CK6Iloe1iBD0_guDA5T.search-service-588df69bd9-2c7hk;
+        path=/search-service
+      X-Request-Id:
+      - 2412127f3f700bc1807b628b2f45912e
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Uniqueid:
+      - 98aaa272-a19e-4a30-9201-fa636fd35b66
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"userid":"agw13","cprid":"2784093","givenName":"Adam","middleName":"Garner","familyName":"Wead","preferredGivenName":"Adam","preferredFamilyName":"Wead","active":true,"confHold":false,"universityEmail":"agw13@psu.edu","serviceAccount":false,"affiliation":["STAFF"],"displayName":"Adam
+        Wead","link":{"href":"https://dev.apps.psu.edu/cpr/resources/2784093"}}'
+  recorded_at: Tue, 23 Nov 2021 17:56:18 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
This works but is semi-complete. This PR adds a service object that will look in the database for a User with a certain webaccess id, if none exists then it will query PSU's identity server and initialize a User with the results.

Both `User.from_omniauth` and `NewDeputyAssignmentForm` share this functionality.

There's still a little work to be done before I would consider this to be fully complete, but seeing as how all of this additional work is kinda in Adam's wheelhouse, I didn't want to tackle it without getting his feedback first:
* `User.from_omniauth` needs to handle the following errors conditions (which it currently does not and never did):
  * When PSU Identity returns `nil` (no user found)
  * When PSU Identity is down (raises IdentityServiceError) Related to #364 
  * When PSU Identity returns a successful response, but that response is deemed invalid by the User model (first or last name is blank)
* `User.update_psu_identity` should also probably use this service class, which will require an additional public method to be added. Frankly I'm not entirely sure what this method does and why (i.e. why does it update the `psu_identity` hash but not the first/last name?) so maybe Adam is better suited to tackle that. Related to #388 

Closes #382 