### PR TITLE
Fixes for when someone is masquerading unbecomes a user

### DIFF
--- a/app/controllers/masquerade_controller.rb
+++ b/app/controllers/masquerade_controller.rb
@@ -8,7 +8,11 @@ class MasqueradeController < UserController
   private
 
     def verify_deputies
-      return if primary_user.available_deputy?(current_user)
+      if current_user.masquerading?
+        return if primary_user.available_deputy?(current_user.impersonator)
+      else
+        return if primary_user.available_deputy?(current_user)
+      end
 
       flash[:alert] = I18n.t('profile.errors.not_authorized')
       redirect_to root_path

--- a/app/controllers/masquerade_controller.rb
+++ b/app/controllers/masquerade_controller.rb
@@ -10,8 +10,8 @@ class MasqueradeController < UserController
     def verify_deputies
       if current_user.masquerading?
         return if primary_user.available_deputy?(current_user.impersonator)
-      else
-        return if primary_user.available_deputy?(current_user)
+      elsif primary_user.available_deputy?(current_user)
+        return
       end
 
       flash[:alert] = I18n.t('profile.errors.not_authorized')

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -64,7 +64,7 @@ class ProfilesController < ProfileManagementController
     end
 
     def path_to_unbecome_user
-      if current_user.admin?
+      if current_user.impersonator.admin?
         admin_unbecomes_user_path(current_user)
       else
         unbecomes_user_path(current_user)

--- a/app/views/shared/_masquerade_navbar.html.erb
+++ b/app/views/shared/_masquerade_navbar.html.erb
@@ -6,8 +6,9 @@
 
   <ul class="navbar-nav ml-auto">
     <li class="nav-item">
-      <%= link_to "Stop being #{current_user.webaccess_id}", path_to_unbecome_user,
-        class: 'nav-link', method: :post %>
+      <%= link_to "Stop being #{current_user.webaccess_id}",
+                  current_user.impersonator.admin? ? admin_unbecomes_user_path(current_user) : unbecomes_user_path(current_user),
+                  class: 'nav-link', method: :post %>
     </li>
   </ul>
 </nav>

--- a/app/views/shared/_masquerade_navbar.html.erb
+++ b/app/views/shared/_masquerade_navbar.html.erb
@@ -6,7 +6,7 @@
 
   <ul class="navbar-nav ml-auto">
     <li class="nav-item">
-      <%= link_to "Stop being #{current_user.webaccess_id}", admin_unbecomes_user_path(current_user),
+      <%= link_to "Stop being #{current_user.webaccess_id}", path_to_unbecome_user,
         class: 'nav-link', method: :post %>
     </li>
   </ul>

--- a/spec/component/controllers/masquerade_controller_spec.rb
+++ b/spec/component/controllers/masquerade_controller_spec.rb
@@ -13,10 +13,11 @@ describe MasqueradeController, type: :controller do
 
     context 'when authenticated' do
       let(:user) { assignment.deputy }
+      let(:current_user) { CurrentUserBuilder.call(current_user: user, current_session: {}) }
 
       before do
         allow(request.env['warden']).to receive(:authenticate!).and_return(user)
-        allow(controller).to receive(:current_user).and_return(user)
+        allow(controller).to receive(:current_user).and_return(current_user)
       end
 
       context 'when the user is a deputy of the primary user' do
@@ -64,11 +65,12 @@ describe MasqueradeController, type: :controller do
 
     context 'when authenticated' do
       let(:user) { assignment.deputy }
+      let(:current_user) { CurrentUserBuilder.call(current_user: user, current_session: session) }
 
       before do
         session[MasqueradingBehaviors::SESSION_ID] = primary.id
         allow(request.env['warden']).to receive(:authenticate!).and_return(user)
-        allow(controller).to receive(:current_user).and_return(user)
+        allow(controller).to receive(:current_user).and_return(current_user)
       end
 
       context 'when the user is an available deputy of the primary user' do

--- a/spec/integration/profiles/edit_spec.rb
+++ b/spec/integration/profiles/edit_spec.rb
@@ -90,6 +90,9 @@ describe 'editing profile preferences' do
           expect(page).to have_link('Unbecome this user')
           click_link('Manage my profile')
           expect(page).to have_link('Stop being abc123')
+          click_link('Stop being abc123')
+          click_link('Become this user')
+          click_link('Unbecome this user')
         end
       end
 
@@ -107,6 +110,9 @@ describe 'editing profile preferences' do
           expect(page).to have_link('Unbecome this user')
           click_link('Manage my profile')
           expect(page).to have_link('Stop being abc123')
+          click_link('Stop being abc123')
+          click_link('Become this user')
+          click_link('Unbecome this user')
         end
       end
     end


### PR DESCRIPTION
@awead Can you check this out?

There was an error popping up when and admin or proxy clicked "Unbecome the User".  To fix this, I added some logic that takes into account that when someone is masquerading, the impersonator should be used when checking if current_user is an admin, or one of the primary's available deputies.