### PR TITLE
.uniq the query array when querying api on Activity Insight ID and DOI

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -584,7 +584,7 @@ class Publication < ApplicationRecord
       .where(publication_imports: {
                source: 'Activity Insight',
                source_identifier: activity_insight_id
-             })
+             }).uniq
   end
 
   def self.filter_by_doi(query, doi)
@@ -599,7 +599,7 @@ class Publication < ApplicationRecord
       doi = url_prefix + doi
     end
 
-    query.where(doi: doi)
+    query.where(doi: doi).uniq
   end
 
   private

--- a/spec/requests/api/v1/publications_spec.rb
+++ b/spec/requests/api/v1/publications_spec.rb
@@ -82,12 +82,14 @@ describe 'API::V1 Publications' do
 
             context 'when the user of the found record is in multiple orgs (query returns multiple of same record)' do
               let!(:org2) { create :organization }
+
               before do
                 create :organization_api_permission, organization: org2, api_token: token
                 user.organizations << org2
                 user.save
                 query_pubs
               end
+
               it 'returns a unique list of publications matching the specified Activity Insight ID', skip_before: true do
                 expect(json_response[:data].size).to eq(1)
                 expect(json_response[:data].first[:attributes][:activity_insight_ids].size).to eq(1)
@@ -125,12 +127,14 @@ describe 'API::V1 Publications' do
 
             context 'when the user of the found record is in multiple orgs (query returns multiple of same record)' do
               let!(:org2) { create :organization }
+
               before do
                 create :organization_api_permission, organization: org2, api_token: token
                 user.organizations << org2
                 user.save
                 query_pubs
               end
+
               it 'returns a unique list of publications matching the specified DOI', skip_before: true do
                 expect(json_response[:data].size).to eq(1)
                 expect(json_response[:data].first[:attributes][:doi]).to eq('https://doi.org/10.26207/46a7-9981')


### PR DESCRIPTION
Sending `#publications` to an instance of `APIToken` will return duplicate records if a user is in multiple organizations.  I'm `uniq`ing the array returned from `Publication.filter_by_activity_insight_id` and `Publication.filter_by_doi` so these duplicates aren't returned by the API.  I added some tests for this too.