### PR TITLE
Fix bug in ORCiD integration by switching to using new method name

### DIFF
--- a/app/controllers/orcid_employments_controller.rb
+++ b/app/controllers/orcid_employments_controller.rb
@@ -10,7 +10,7 @@ class OrcidEmploymentsController < UserController
       else
         employment = OrcidEmployment.new(membership)
         employment.save!
-        membership.update_attributes!(orcid_resource_identifier: employment.location)
+        membership.update!(orcid_resource_identifier: employment.location)
 
         flash[:notice] = I18n.t('profile.orcid_employments.create.success')
       end

--- a/spec/component/controllers/orcid_employments_controller_spec.rb
+++ b/spec/component/controllers/orcid_employments_controller_spec.rb
@@ -29,7 +29,7 @@ describe OrcidEmploymentsController, type: :controller do
         let(:membership) { double 'user organization membership',
                                   started_on: Date.new(1999, 12, 31),
                                   orcid_resource_identifier: id,
-                                  update_attributes!: nil }
+                                  update!: nil }
 
         context "when the employment has already been added to the user's ORCID record" do
           let(:id) { 'abc123' }
@@ -51,7 +51,7 @@ describe OrcidEmploymentsController, type: :controller do
           end
 
           it 'updates the membership with the identifier of the employment that was created in ORCID' do
-            expect(membership).to have_received(:update_attributes!).with(orcid_resource_identifier: 'the_location')
+            expect(membership).to have_received(:update!).with(orcid_resource_identifier: 'the_location')
           end
 
           it 'sets a flash message' do


### PR DESCRIPTION
I noticed an error in Bugsnag related to someone trying to add employment info to ORCiD. It turned out to be a regression caused by the last Rails upgrade that we didn't catch because our tests in this area are a little thin. I went ahead and made the fix since it was quick, but I haven't done anything to improve the associated tests. That might be an item for future consideration.